### PR TITLE
add `handler` option to repl task

### DIFF
--- a/boot/core/src/boot/repl_server.clj
+++ b/boot/core/src/boot/repl_server.clj
@@ -78,7 +78,9 @@
         init-ns        (or init-ns 'boot.user)
         init-ns-mw     [(wrap-init-ns init-ns)]
         middleware     (concat init-ns-mw *default-middleware* middleware)
-        handler        (or handler (apply server/default-handler middleware))
+        handler        (if handler
+                         (resolve handler)
+                         (apply server/default-handler middleware))
         opts           (->> (-> (assoc opts :handler handler)
                               (select-keys [:bind :port :handler]))
                          (reduce-kv #(if-not %3 %1 (assoc %1 %2 %3)) {}))

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -182,9 +182,10 @@
    I skip-init      bool   "Skip default client initialization code."
    p port PORT      int    "The port to listen on and/or connect to."
    n init-ns NS     sym    "The initial REPL namespace."
-   m middleware SYM [code] "The REPL middleware vector."]
+   m middleware SYM [code] "The REPL middleware vector."
+   x handler SYM     sym   "The REPL handler, when used middleware option is ignored"]
 
-  (let [srv-opts (select-keys *opts* [:bind :port :init-ns :middleware])
+  (let [srv-opts (select-keys *opts* [:bind :port :init-ns :middleware :handler])
         cli-opts (-> *opts*
                    (select-keys [:host :port :history])
                    (assoc :color (not no-color)
@@ -197,6 +198,7 @@
                                (pod/add-dependencies
                                  (update-in (core/get-env) [:dependencies]
                                    conj '[org.clojure/tools.nrepl "0.2.4"]))))
+                   (if handler (require (symbol (namespace handler))))
                    (require 'boot.repl-server)
                    ((resolve 'boot.repl-server/start-server) srv-opts))
         repl-cli (delay (pod/call-worker `(boot.repl-client/client ~cli-opts)))]


### PR DESCRIPTION
This commits allows users to specify a custom handler
function when running the repl task:

``` clojure
user=> (boot (repl :handler 'cider.nrepl/cider-nrepl-handler)))
```

The line above requires cider/cider-nrepl to be specified
as dependency. From the command line you can do that and
start the REPL like so:

```
boot -d cider/cider-nrepl:0.8.0-SNAPSHOT repl -x cider.nrepl/cider-nrepl-handler
```
