### PR TITLE
Update fake.class.path when adding dependencies

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -163,6 +163,7 @@
   "Add Maven dependencies to the classpath, fetching them if necessary."
   [old new env]
   (->> new rm-clojure-dep (assoc env :dependencies) pod/add-dependencies)
+  (set-fake-class-path!)
   new)
 
 (defn- add-directories!


### PR DESCRIPTION
This fixes an issue where the `fake.class.path` property did not contain dependencies added via `set-env!`. (Also, it should make vim-boot work close to 100% for file jumping!)
