### PR TITLE
Bump tools.nrepl and reply versions for vim-fireplace compatibility

### DIFF
--- a/boot/core/src/boot/repl.clj
+++ b/boot/core/src/boot/repl.clj
@@ -1,7 +1,7 @@
 (ns boot.repl)
 
 (def ^:dynamic *default-dependencies*
-  (atom '[[org.clojure/tools.nrepl "0.2.4"]]))
+  (atom '[[org.clojure/tools.nrepl "0.2.6"]]))
 
 (def ^:dynamic *default-middleware*
   (atom ['boot.from.io.aviso.nrepl/pretty-middleware]))

--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -17,7 +17,7 @@
   :dependencies [[org.clojure/clojure         "1.6.0"  :scope "provided"]
                  [boot/base                   ~version :scope "provided"]
                  [boot/aether                 ~version :scope "compile"]
-                 [reply                       "0.3.4"  :scope "compile"]
+                 [reply                       "0.3.5"  :scope "compile"]
                  [cheshire                    "5.3.1"  :scope "compile"]
                  [clj-jgit                    "0.8.0"  :scope "compile"]
                  [clj-yaml                    "0.4.0"  :scope "compile"]


### PR DESCRIPTION
I noticed something really strange with vim-boot that I wanted to run by you.

At a high level, error output is not printed when you evaluate things. At a low level, the nrepl response `boot repl` is returning excludes the 'err' key, while the response return by a `lein repl` _includes_ it. This is the value vim-fireplace uses to display error messages for failed invocations.

Turns out lein's REPL is "REPL-y 0.3.5, nREPL 0.2.6", while boot's is "REPL-y 0.3.4, nREPL 0.2.4".

There seem to be enough subtle differences between the versions, that vim-fireplace does not correctly output error messages without upgrading them.
