### PR TITLE
Add load-data-readers! function

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -159,6 +159,12 @@
   [deps]
   (vec (remove (comp (partial = 'org.clojure/clojure) first) deps)))
 
+(defn load-data-readers!
+  "Refresh *data-readers* with readers from newly acquired dependencies."
+  []
+  (#'clojure.core/load-data-readers)
+  (set! *data-readers* (.getRawRoot #'*data-readers*)))
+
 (defn- add-dependencies!
   "Add Maven dependencies to the classpath, fetching them if necessary."
   [old new env]


### PR DESCRIPTION
Potential fix for #47. This one is definitely "take it or leave it."

This proposal adds a `load-data-readers!` function to core that users can call after `set-env!` to load data readers from dependencies. I'm not 100% sold this is the right thing to do, however, when I tried adding `load-data-readers!` to `add-dependencies!` or `set-env!`, I see the following error on REPL launch:

``` sh
java.lang.IllegalStateException: Can't change/establish root binding of: *data-readers* with set
                         ...
boot.core/load-data-readers!  core.clj: 167
          boot.core/set-env!  core.clj: 457
                         ...
        boot.core/temp-dir**  core.clj:  81
                         ...
             boot.core/init!  core.clj: 406
                         ...
             boot.main/-main  main.clj: 121
                         ...
            boot.App.runBoot  App.java: 217
               boot.App.main  App.java: 309
```
