### PR TITLE
Added fileset-removed function

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -256,6 +256,11 @@
   [before after]
   (tmpd/diff before after))
 
+(defn fileset-removed
+  "Returns a new fileset containing files that were removed."
+  [before after]
+  (tmpd/removed before after))
+
 ;; TmpFileSet API
 
 (defn user-dirs

--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -111,3 +111,10 @@
     (let [t1 (:tree this)
           t2 (:tree fileset)]
       (->> (data/diff t1 t2) second keys (select-keys t2) (assoc fileset :tree)))))
+
+(defn removed [this fileset]
+  (if-not fileset
+    this
+    (let [t1 (:tree this)
+          t2 (:tree fileset)]
+      (->> (data/diff t1 t2) first keys (select-keys t1) (assoc fileset :tree)))))


### PR DESCRIPTION
The fileset-removed function can be used to create fileset containing
the files only present on `before` but not on `after` fileset.
