### PR TITLE
fix debounce opt on watch task

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -162,7 +162,6 @@
                     (try (reset! return (-> fileset core/reset-fileset core/commit! next-task))
                          (catch Throwable ex (util/print-ex ex)))
                     (util/info "Elapsed time: %.3f sec\n\n" (float (/ (etime) 1000)))))
-                (println "recuring...")
                 (recur (util/guard [(.take q)]))))))
         @return))))
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -130,7 +130,7 @@
   Debouncing time is 10ms by default."
 
   [q quiet         bool "Suppress all output from running jobs."
-   d debounce MSEC long "The time to wait (millisec) for filesystem to settle down."
+   d debounce MSEC int "The time to wait (millisec) for filesystem to settle down."
    v verbose       bool "Print which files have changed."]
 
   (pod/require-in @pod/worker-pod "boot.watcher")
@@ -162,6 +162,7 @@
                     (try (reset! return (-> fileset core/reset-fileset core/commit! next-task))
                          (catch Throwable ex (util/print-ex ex)))
                     (util/info "Elapsed time: %.3f sec\n\n" (float (/ (etime) 1000)))))
+                (println "recuring...")
                 (recur (util/guard [(.take q)]))))))
         @return))))
 
@@ -248,7 +249,7 @@
 
   The include and exclude options specify sets of regular expressions that will
   be used to filter the fileset.
-  
+
   The move option applies a find/replace transformation on all paths in the
   output fileset."
 


### PR DESCRIPTION
boot was throwing an error attempting to look up type long in boot.cli/assert-atom & clojure ints are longs anyways. ps what's with the ghost new line change below @ line 251?