### PR TITLE
RFC: Relative-to should now work even if file is not inside base

### DIFF
--- a/boot/pod/test/boot/file_test.clj
+++ b/boot/pod/test/boot/file_test.clj
@@ -1,0 +1,31 @@
+(ns boot.file-test
+  (:refer-clojure :exclude [sync file-seq])
+  (:require
+    [clojure.test :refer :all]
+    [boot.file :as file :refer :all :exclude [name]]
+    [clojure.java.io :as io]))
+
+(def test-dir (.getParentFile (io/file "public/js/main.js")))
+(def abs-dir  (.getParentFile (io/file "/foo/bar/main.js")))
+
+(deftest parent-seq-test
+  (let [f (io/file "public/js/main.js")]
+    (is (= (seq [f (parent f) (parent (parent f))]) (parent-seq f)))))
+
+(deftest parent?-test
+  (is (parent? test-dir (io/file "public/js/out/goog/base.js")))
+  (is (not (parent? test-dir (io/file "foo/js/public/out/goog/base.js")))))
+
+(deftest relative-to-test
+  (testing "File inside base"
+    (is (= "out/goog/base.js"          (str (relative-to test-dir (io/file "public/js/out/goog/base.js"))))))
+
+  (testing "File not inside base"
+    (is (= "../../cljsjs/dev/react.js" (str (relative-to test-dir (io/file "cljsjs/dev/react.js"))))))
+
+  (testing "File not inside base"
+    (is (= "../cljsjs/dev/react.js"    (str (relative-to test-dir (io/file "public/cljsjs/dev/react.js"))))))
+
+  (testing "Two absolute paths"
+    (is (= "js/test.js"                (str (relative-to abs-dir  (io/file "/foo/bar/js/test.js"))))))
+  )


### PR DESCRIPTION
URI's relativize method works a bit badly if the file is not inside base.

These changes should work around deficiencies of relativize. If file is not found inside base it'll walk upwards from base and prefix the result with some ".."s.

It's probably best if I still edit this a bit before possible merge:

1. Are up-parents and shared-parent used anywhere? Not in boot code base I think?
2. Should following cases be supported:
  - Base is a file: public/js/main.js, public/js/out/foo.js => out/foo.js. Currently doesn't work.
  - Base if absolute path and file is relative? What should happen?