### PR TITLE
Fix invalid key failure in watcher thread

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -162,7 +162,6 @@
                     (try (reset! return (-> fileset core/reset-fileset core/commit! next-task))
                          (catch Throwable ex (util/print-ex ex)))
                     (util/info "Elapsed time: %.3f sec\n\n" (float (/ (etime) 1000)))))
-                (println "recuring...")
                 (recur (util/guard [(.take q)]))))))
         @return))))
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -130,7 +130,7 @@
   Debouncing time is 10ms by default."
 
   [q quiet         bool "Suppress all output from running jobs."
-   d debounce MSEC long "The time to wait (millisec) for filesystem to settle down."
+   d debounce MSEC int "The time to wait (millisec) for filesystem to settle down."
    v verbose       bool "Print which files have changed."]
 
   (pod/require-in @pod/worker-pod "boot.watcher")
@@ -162,6 +162,7 @@
                     (try (reset! return (-> fileset core/reset-fileset core/commit! next-task))
                          (catch Throwable ex (util/print-ex ex)))
                     (util/info "Elapsed time: %.3f sec\n\n" (float (/ (etime) 1000)))))
+                (println "recuring...")
                 (recur (util/guard [(.take q)]))))))
         @return))))
 
@@ -248,7 +249,7 @@
 
   The include and exclude options specify sets of regular expressions that will
   be used to filter the fileset.
-  
+
   The move option applies a find/replace transformation on all paths in the
   output fileset."
 

--- a/boot/worker/src/boot/watcher.clj
+++ b/boot/worker/src/boot/watcher.clj
@@ -95,7 +95,9 @@
                        (cond
                          (and dir? (= :create etype)) (doreg service changed)
                          (not dir?) (.offer queue (.getPath changed)))))
-                   (and watch-key (.reset watch-key) (recur))))))
+                 (if-not (.reset watch-key)
+                   (util/dbug "failed to reset watch key %s\n" (.watchable watch-key)))
+                 (recur)))))
       Thread. .start)
     service))
 


### PR DESCRIPTION
Same issue as boot-clj/boot#31

```
A watch key is created when a watchable object is registered with a watch service. The key remains valid until:

It is cancelled, explicitly, by invoking its cancel method, or
Cancelled implicitly, because the object is no longer accessible, or
By closing the watch service.
```
So when a directory that is being watched gets deleted & recreated, it's watch key will become invalid. This is ok and normal if the directory's parent is also being watched - the watcher will simply recur and upon taking the parent's watch key, it will re-register the directory. However, if the deletion and re-creation occurs after watch key validation and before watch key reset, the watcher thread will exit. We wan't to prevent this as it breaks the watch task. Even if resetting the watch key fails, we should still recur and have the watchable's parent re-register any new additions and carry on.

However there is an issue when the top level watchable get's deleted, which is fatal for the watcher, and should be handled separately.

(ps. I still have older commits on my fork that represent older pull requests, should I remove those for future pull requests? ty)