### PR TITLE
Relative-to nil base test case and small changes

### DIFF
--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -23,6 +23,7 @@
 (defn exists? [f] (when (try (.exists (io/file f)) (catch Throwable _)) f))
 (defn path [f] (.getPath (io/file f)))
 (defn name [f] (.getName (io/file f)))
+(defn parent [f] (.getParentFile (io/file f)))
 (defn file-seq [dir] (when dir (clojure.core/file-seq dir)))
 
 (defmacro guard [& exprs]
@@ -55,13 +56,14 @@
 (defn parent-seq
   "Return sequence of this file and all it's parent directories"
   [f]
-  (->> f io/file (iterate #(.getParentFile %)) (take-while identity)))
+  (->> f io/file (iterate parent) (take-while identity)))
 
-(defn split-path [p]
+(defn split-path
+  "Return sequence of this file's and its parent directories names.
+
+   e.g. public/js/main.js -> (\"public\" \"js\" \"main.js\")"
+  [p]
   (->> p parent-seq reverse (map (memfn getName))))
-
-(defn parent [f]
-  (.getParentFile f))
 
 (defn parent? [parent child]
   (contains? (set (parent-seq child)) parent))

--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -77,26 +77,6 @@
         (recur (parent base) (conj parts "..")))
       (URI. (str (apply io/file (concat parts (split-path f))))))))
 
-; FIXME: Is this useful for anything?
-(defn up-parents
-  [f base & parts]
-  (->> (io/file f)
-    (relative-to (io/file base))
-    (.getPath)
-    parent-seq
-    butlast
-    (map (constantly ".."))
-    (concat (reverse parts))
-    reverse
-    (apply io/file)
-    (.getPath)))
-
-; FIXME: Is this useful for anything?
-(defn shared-parent
-  [file1 file2]
-  (let [p1 (set (parent-seq file1))]
-    (->> file2 parent-seq (drop-while #(not (contains? p1 %))) first)))
-
 (defn lockfile
   [f]
   (let [f (io/file f)]

--- a/boot/pod/test/boot/file_test.clj
+++ b/boot/pod/test/boot/file_test.clj
@@ -5,18 +5,25 @@
     [boot.file :as file :refer :all :exclude [name]]
     [clojure.java.io :as io]))
 
-(def test-dir (.getParentFile (io/file "public/js/main.js")))
-(def abs-dir  (.getParentFile (io/file "/foo/bar/main.js")))
+(def test-file (io/file "public/js/main.js"))
+(def test-dir (parent test-file))
+(def abs-dir  (parent (io/file "/foo/bar/main.js")))
 
 (deftest parent-seq-test
-  (let [f (io/file "public/js/main.js")]
+  (let [f test-file]
     (is (= (seq [f (parent f) (parent (parent f))]) (parent-seq f)))))
+
+(deftest split-path-test
+  (is (= (seq ["public" "js" "main.js"]) (split-path test-file))))
 
 (deftest parent?-test
   (is (parent? test-dir (io/file "public/js/out/goog/base.js")))
   (is (not (parent? test-dir (io/file "foo/js/public/out/goog/base.js")))))
 
 (deftest relative-to-test
+  (testing "Nil base"
+    (is (= "out/goog/base.js"          (str (relative-to nil      (io/file "out/goog/base.js"))))))
+
   (testing "File inside base"
     (is (= "out/goog/base.js"          (str (relative-to test-dir (io/file "public/js/out/goog/base.js"))))))
 


### PR DESCRIPTION
This adds one good test case to relative-to: nil base

Other notable change is removal of up-parents and shared-parent functions. I'm quite confident that they are not useful. If I guess right they were added to go around deficiencies of URI.relativize.