### PR TITLE
throw a descriptive exception when the java compiler cannot be used

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -443,7 +443,8 @@
     (core/with-pre-wrap fileset
       (let [throw?    (atom nil)
             diag-coll (DiagnosticCollector.)
-            compiler  (ToolProvider/getSystemJavaCompiler)
+            compiler  (or (ToolProvider/getSystemJavaCompiler)
+                          (throw (Exception. "The java compiler is not working. Please make sure you use a JDK!")))
             file-mgr  (.getStandardFileManager compiler diag-coll nil nil)
             opts      (->> ["-d"  (.getPath tgt)
                             "-cp" (System/getProperty "boot.class.path")]


### PR DESCRIPTION
this may happen when running on a JRE instead of a full blown JDK.