### PR TITLE
return a File object from relative-to

### DIFF
--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -75,9 +75,9 @@
          parts []]
     (if base
       (if (parent? base f)
-        (URI. (str (apply io/file (concat parts [(str (.relativize (.toURI base) (.toURI f)))]))))
+        (apply io/file (concat parts [(str (.relativize (.toURI base) (.toURI f)))]))
         (recur (parent base) (conj parts "..")))
-      (URI. (str (apply io/file (concat parts (split-path f))))))))
+      (apply io/file (concat parts (split-path f))))))
 
 (defn lockfile
   [f]


### PR DESCRIPTION
this fixes https://github.com/boot-clj/boot/issues/85

The callers call .getPath on the return value of this function so it
shouldn't matter.

however tmpdir's dir->tree calls str on the return value. It may need to
be adapted...