### PR TITLE
fix NPE in javac task

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -460,16 +460,20 @@
                                Arrays/asList
                                (.getJavaFileObjectsFromFiles file-mgr))]
         (when srcs
-          (util/info "Compiling Java classes...\n")
+          (util/info "Compiling %d Java source files...\n" (count srcs))
           (-> compiler (.getTask *err* file-mgr diag-coll opts nil srcs) .call)
           (doseq [d (.getDiagnostics diag-coll) :let [k (.getKind d)]]
             (when (= Diagnostic$Kind/ERROR k) (reset! throw? true))
             (let [log (handler k util/info)]
-              (log "%s: %s, line %d: %s\n"
-                   (.toString k)
-                   (.. d getSource getName)
-                   (.getLineNumber d)
-                   (.getMessage d nil))))
+              (if (nil? (.getSource d))
+                (log "%s: %s\n"
+                     (.toString k)
+                     (.getMessage d nil))
+                (log "%s: %s, line %d: %s\n"
+                     (.toString k)
+                     (.. d getSource getName)
+                     (.getLineNumber d)
+                     (.getMessage d nil)))))
           (.close file-mgr)
           (when @throw? (throw (Exception. "java compiler error")))))
       (-> fileset (core/add-resource tgt) core/commit!))))


### PR DESCRIPTION
handle the case where (.getSource d) returns nil. I ran into that with
the following warning:

,----
| WARNING: Supported source version 'RELEASE_6' from annotation processor
| 'org.sonatype.guice.bean.scanners.index.SisuIndexAPT6' less than -source
| '1.8'
`----

While I'm here, also show the number of files being compiled.