### PR TITLE
catch errors when unpacking jars in order to fix problems in windows

### DIFF
--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -285,7 +285,11 @@
   (doseq [[path url] (jar-entries jar)]
     (let [out   (io/file dir path)
           keep? (partial file/keep-filters? include exclude)]
-      (when (keep? (io/file path)) (copy-url url out)))))
+      (when (keep? (io/file path))
+        (try
+          (copy-url url out)
+          (catch Exception err
+            (util/warn "Error while extracting %s: %s\n" url err)))))))
 
 (defn jars-dep-graph
   [env]


### PR DESCRIPTION
some of my jars contain files such as

/LICENSE
/license/LICENSE.txt

which breaks when running on a case-insensitive filesystem.

log an error in that case and go on