### PR TITLE
turn off colorization on Windows by default

### DIFF
--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -121,7 +121,8 @@
               scriptstr   (binding [*print-meta* true]
                             (str (string/join "\n\n" (map pr-str scriptforms)) "\n"))]
 
-          (reset! util/*colorize?* (not (:no-colors opts)))
+          (when (:no-colors opts)
+            (reset! util/*colorize?* false))
           (swap! util/*verbosity* + verbosity)
           (pod/with-eval-in worker-pod
             (require '[boot.util :as util])

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -197,7 +197,7 @@
   (let [srv-opts (select-keys *opts* [:bind :port :init-ns :middleware :handler])
         cli-opts (-> *opts*
                      (select-keys [:host :port :history])
-                     (assoc :color (not no-color)
+                     (assoc :color (if no-color false (util/colorize?-system-default))
                             :standalone true
                             :custom-eval eval
                             :custom-init init

--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -18,8 +18,23 @@
 
 (declare print-ex)
 
+(defn colorize?-system-default
+  "return whether we should colorize output on this system. This is
+  true, unless we're on Windows, where this is false. The default
+  console on Windows does not interprete ansi escape codes. The
+  default can be overriden by setting the environment variable
+  BOOT_COLOR=1 to turn it on or BOOT_COLOR=0 to turn it off"
+  []
+  (cond
+    (System/getenv "BOOT_COLOR")
+      (= "1" (System/getenv "BOOT_COLOR"))
+    (.startsWith (System/getProperty "os.name") "Windows")
+      false
+    :else
+      true))
+
 (def ^:dynamic *verbosity* (atom 1))
-(def ^:dynamic *colorize?* (atom true))
+(def ^:dynamic *colorize?* (atom (colorize?-system-default)))
 
 (defn- print*
   [verbosity args]


### PR DESCRIPTION
The default Windows console does not support the color escape codes, so
this should result in a much better first experience with boot.
Since there are ways to make the escape codes work, allow to turn them
on by setting the environment variable BOOT_COLOR=1.
BOOT_COLOR=0 can be used to turn off colorization on unix platforms
without specifying a command line argument.

see https://github.com/boot-clj/boot/issues/99