### PR TITLE
Fix #125: expose *arg-zero* to boot scripts

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -23,10 +23,11 @@
 
 (declare watch-dirs sync! post-env! get-env set-env! tmpfile tmpdir ls)
 
-(declare ^{:dynamic true :doc "The running version of boot app."}      *app-version*)
-(declare ^{:dynamic true :doc "The running version of boot core."}     *boot-version*)
-(declare ^{:dynamic true :doc "Command line options for boot itself."} *boot-opts*)
-(declare ^{:dynamic true :doc "Count of warnings during build."}       *warnings*)
+(declare ^{:dynamic true :doc "The running version of boot app."}        *app-version*)
+(declare ^{:dynamic true :doc "The script's name (when run as script)."} *arg-zero*)
+(declare ^{:dynamic true :doc "The running version of boot core."}       *boot-version*)
+(declare ^{:dynamic true :doc "Command line options for boot itself."}   *boot-opts*)
+(declare ^{:dynamic true :doc "Count of warnings during build."}         *warnings*)
 
 (def last-file-change "Last source file watcher update time." (atom 0))
 

--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -101,7 +101,8 @@
               *err*               (util/auto-flush *err*)
               core/*boot-opts*    opts
               core/*boot-version* (boot.App/getBootVersion)
-              core/*app-version*  (boot.App/getVersion)]
+              core/*app-version*  (boot.App/getVersion)
+              core/*arg-zero*     arg0]
       (util/exit-ok
         (let [userscript  (-> (System/getProperty "user.home")
                               (io/file ".profile.boot")


### PR DESCRIPTION
Simple change to expose the script's filename to the script via core/*arg-zero* -- does this look ok?