### PR TITLE
Suppress updates when running show --fake-classpath

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -107,7 +107,7 @@
    c classpath        bool "Print the project's full classpath."
    C fake-classpath   bool "Print the project's fake classpath."]
 
-  (let [updates (or updates update-snapshots (not (or deps env fileset classpath)))]
+  (let [updates (or updates update-snapshots (not (or deps env fileset classpath fake-classpath)))]
     (core/with-pre-wrap fileset'
       (when deps    (print (pod/with-call-worker (boot.aether/dep-tree ~(core/get-env)))))
       (when env     (println (pr-str (core/get-env))))


### PR DESCRIPTION
I missed this before, but the `--fake-classpath` flag was implicitly also printing updates.