### PR TITLE
Push seq regexes

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -635,19 +635,20 @@
   look for jar files created by the build pipeline. The jar file(s) must contain
   pom.xml entries."
 
-  [f file PATH            str  "The jar file to deploy."
-   g gpg-sign             bool "Sign jar using GPG private key."
-   k gpg-user-id NAME     str  "The name used to find the GPG key."
-   K gpg-keyring PATH     str  "The path to secring.gpg file to use for signing."
-   p gpg-passphrase PASS  str  "The passphrase to unlock GPG signing key."
-   r repo ALIAS           str  "The alias of the deploy repository."
-   t tag                  bool "Create git tag for this version."
-   B ensure-branch BRANCH str  "The required current git branch."
-   C ensure-clean         bool "Ensure that the project git repo is clean."
-   R ensure-release       bool "Ensure that the current version is not a snapshot."
-   S ensure-snapshot      bool "Ensure that the current version is a snapshot."
-   T ensure-tag TAG       str  "The SHA1 of the commit the pom's scm tag must contain."
-   V ensure-version VER   str  "The version the jar's pom must contain."]
+  [f file PATH            str      "The jar file to deploy."
+   F file-regex MATCH     #{regex} "The set of regexes of paths to deploy."
+   g gpg-sign             bool     "Sign jar using GPG private key."
+   k gpg-user-id NAME     str      "The name used to find the GPG key."
+   K gpg-keyring PATH     str      "The path to secring.gpg file to use for signing."
+   p gpg-passphrase PASS  str      "The passphrase to unlock GPG signing key."
+   r repo ALIAS           str      "The alias of the deploy repository."
+   t tag                  bool     "Create git tag for this version."
+   B ensure-branch BRANCH str      "The required current git branch."
+   C ensure-clean         bool     "Ensure that the project git repo is clean."
+   R ensure-release       bool     "Ensure that the current version is not a snapshot."
+   S ensure-snapshot      bool     "Ensure that the current version is a snapshot."
+   T ensure-tag TAG       str      "The SHA1 of the commit the pom's scm tag must contain."
+   V ensure-version VER   str      "The version the jar's pom must contain."]
 
   (let [tgt (core/tmp-dir!)]
     (core/with-pre-wrap fileset
@@ -656,6 +657,7 @@
         (let [jarfiles (or (and file [(io/file file)])
                            (->> (core/output-files fileset)
                                 (core/by-ext [".jar"])
+                                ((if (seq file-regex) #(core/by-re file-regex %) identity))
                                 (map core/tmp-file)))
               repo-map (->> (core/get-env :repositories) (into {}))
               r        (get repo-map repo)]


### PR DESCRIPTION
This pull request was created to address issue with push task. It is not possible to push one of the jar files if they were generated by previous task in the pipeline and is located at some temp dir. You can't use -f flag, because you don't know path to the temp dir and it could be changed. Also you can't on the default behavior because you have several jar files, and you don't want all them to be deploy, or the can't be deployed. 

So I introduce new flag -F or --file-regex that will take regex seq and filter all jar files that was found in output-files. This will allow you to control the process of push. Example of usages:

    boot push -F #"-SNAPSHOT.jar$" # deploy only snapshots  
    boot push -F #"some_jar.jar$"  # deploy specific file