### PR TITLE
Copy with attributes

### DIFF
--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -9,6 +9,7 @@
    [java.net URI]
    [java.nio.file Files]
    [java.nio.file.attribute FileAttribute]
+   [java.nio.file StandardCopyOption]
    [java.lang.management ManagementFactory])
   (:refer-clojure :exclude [sync name file-seq]))
 
@@ -133,16 +134,14 @@
 
 (defn copy-with-lastmod
   [src-file dst-file]
-  (let [last-mod (.lastModified src-file)
-        cp-src!  (partial io/copy src-file)
+  (let [cp-src!  (partial io/copy src-file)
         dst-par  (.getParent dst-file)]
     (io/make-parents dst-file)
     (when-not (.canWrite (io/file dst-par))
       (throw (ex-info (format "Can't write to directory (%s)." dst-par) {:dir dst-par})))
-    (when (.exists dst-file) (.delete dst-file))
     (if *hard-link*
       (hard-link src-file dst-file)
-      (doto dst-file cp-src! (.setLastModified last-mod)))))
+      (cp-src! dst-file StandardCopyOption/REPLACE_EXISTING StandardCopyOption/COPY_ATTRIBUTES))))
 
 (defn copy-files
   [src dest]


### PR DESCRIPTION
This commit uses `copy` with the `StandardCopyOption` enums.
Related to  #189.

By using the specified options, we can get rid of the following in `copy-with-lastmod`:

* checking if destination exists, and deleting it if it does
* setting last modified attribute.

Additionally, we copy files with other attributes that were previously ignored.
 