### PR TITLE
Fix file handle leaks when unpacking JAR files

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -103,7 +103,6 @@
             (core/empty-dir! tmp)
             (util/info "Checking out %s...\n" path)
             (pod/unpack-jar (.getPath file) tmp
-              :cache false
               :exclude pod/standard-jar-exclusions)))
         (->> tmps vals (reduce core/add-source fileset) core/commit!)))))
 


### PR DESCRIPTION
Currently, unpacking entries from JAR files is done by first enumerating the entries, constructing JAR entry URLs, like `jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class` and subsequently opening `InputStream`s on these URLs.

However, using URLs to open streams for JAR file entries appears to be problematic.

I got a "Too many open files" exception when using `uber` task and tracked the problem down to the following:

For each file being unpacked from the JAR, a file handle is opened for the JAR file, and for the destination file, however, as the following `strace` output shows, only the destination file handle is closed. The JAR file handle remains open.

```
8924  open("/home/ragge/.m2/repository/cheshire/cheshire/5.4.0/cheshire-5.4.0.jar", O_RDONLY) = 147
8924  open("/nix/store/c00cymmlb0p05wrr7wq1h11yqqd8i75r-oraclejdk-8u45/jre/lib/content-types.properties", O_RDONLY) = 148
8924  close(148)                        = 0
8924  open("/home/ragge/.boot/cache/tmp/home/ragge/projects/github/redacted/redacted/6v2/4naatj/project.clj", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 148
8924  close(148)                        = 0
8924  open("/home/ragge/.m2/repository/cheshire/cheshire/5.4.0/cheshire-5.4.0.jar", O_RDONLY) = 148
8924  open("/home/ragge/.boot/cache/tmp/home/ragge/projects/github/redacted/redacted/6v2/4naatj/META-INF/leiningen/cheshire/cheshire/README.md", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 151
8924  close(151)                        = 0
8924  open("/home/ragge/.m2/repository/cheshire/cheshire/5.4.0/cheshire-5.4.0.jar", O_RDONLY) = 151
8924  open("/home/ragge/.boot/cache/tmp/home/ragge/projects/github/redacted/redacted/6v2/4naatj/META-INF/leiningen/cheshire/cheshire/LICENSE", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 152
8924  close(152)                        = 0
8924  open("/home/ragge/.m2/repository/cheshire/cheshire/5.4.0/cheshire-5.4.0.jar", O_RDONLY) = 152
8924  open("/home/ragge/.boot/cache/tmp/home/ragge/projects/github/redacted/redacted/6v2/4naatj/cheshire/core.clj", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 153
8924  close(153)                        = 0
8924  open("/home/ragge/.m2/repository/cheshire/cheshire/5.4.0/cheshire-5.4.0.jar", O_RDONLY) = 153
8924  open("/home/ragge/.boot/cache/tmp/home/ragge/projects/github/redacted/redacted/6v2/4naatj/cheshire/custom.clj", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 154
8924  close(154)                        = 0
```

This PR uses `JarFile` to explicitly open a jar file and process the entries. This fixes the problem I was seeing, and as a bonus, the JAR file is only opened once, all entries processed, and then closed.