### PR TITLE
Make `new-fileset` public

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -70,7 +70,7 @@
   [key]
   (tmp/mkdir! @tmpregistry key))
 
-(def ^:private new-fileset
+(def new-fileset
   (memoize
     (fn []
       (boot.tmpdir.TmpFileSet. @tempdirs {} (tmp-dir* ::blob)))))


### PR DESCRIPTION
The background for this comes from http://hoplon.discoursehosting.net/t/changing-resource-paths-in-between-tasks-compostions/522

I was able to achieve this using

```clojure
(core/deftask cljsbuild
  []
  (core/set-env! :resource-paths #{})
  (comp
    (fn [nxt]
      (fn [fileset]
        (print "Resetting fileset..\n")
        (nxt (core/new-fileset))))
    (cljs)))
```