### PR TITLE
Add credentials options to `push` task.

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -688,6 +688,7 @@
 
   [f file PATH            str      "The jar file to deploy."
    F file-regex MATCH     #{regex} "The set of regexes of paths to deploy."
+   c credentials PATH     str      "The path to credentials file for repositores."
    g gpg-sign             bool     "Sign jar using GPG private key."
    k gpg-user-id NAME     str      "The name used to find the GPG key."
    K gpg-keyring PATH     str      "The path to secring.gpg file to use for signing."
@@ -711,7 +712,12 @@
                                 ((if (seq file-regex) #(core/by-re file-regex %) identity))
                                 (map core/tmp-file)))
               repo-map (->> (core/get-env :repositories) (into {}))
-              r        (get repo-map repo)]
+              r        (get repo-map repo)
+              r        (if (and r credentials)
+                         (->> credentials slurp read-string
+                              (some (fn [[k v]] (when (or (= k (:url r)) (re-find k (:url r))) v)))
+                              (merge r))
+                         r)]
           (when-not (and r (seq jarfiles))
             (throw (Exception. "missing jar file or repo not found")))
           (doseq [f jarfiles]


### PR DESCRIPTION
This allows adding credentials on-the-fly from a given file path. The credentials file contains a clojure map and has keys either exact url string or regex that finds itself in repo url. e.g.

```clojure
{#"clojars" {:username "foo" :password "bar"}
 #"aws-private-repo-bucket" {:username "...." :passphrase "..."}
 "http://somerepo/release" {:username "...." :password "..."}}
```