### PR TITLE
make environment variable BOOT_LOCAL_REPO usable on windows

### DIFF
--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -282,7 +282,7 @@ public class App {
 
         String dir_l  = (localrepo == null)
             ? "boot/default"
-            : "boot/custom" + (new File(localrepo)).getCanonicalFile().getPath();
+            : "boot/custom/" + (new File(localrepo)).getCanonicalFile().getPath().replaceAll("[:/\\\\]+", "-");
         
         if (clj_v != null) cljversion = clj_v;
         if (boot_v != null) bootversion = boot_v;


### PR DESCRIPTION
replace special characters when building path components when the
environment variable BOOT_LOCAL_REPO is set.
Previously we ended up trying to use illegal filenames like
C:\home\.boot\cache\boot\customC:\home\.m2\... on windows.

Since we now also replace the path separators, we use a single directory
under boot/custom/ instead of a deep directory structure.

This may lead to a single path component being too long. But that is a
future issue.

see https://github.com/boot-clj/boot/issues/243 for more information.