### PR TITLE
make environment variable BOOT_LOCAL_REPO usable on windows

### DIFF
--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -176,7 +176,12 @@ public class App {
             ensureResourceFile(aetherjar, aetherfile);
             aethershim = newShim(new File[] { aetherfile }); }
         return aethershim; }
-        
+
+    private static String
+    md5hash(String data) throws Exception {
+        java.security.MessageDigest algo = java.security.MessageDigest.getInstance("MD5");
+        return javax.xml.bind.DatatypeConverter.printHexBinary(algo.digest(data.getBytes())); }
+
     public static void
     extractResource(String resource, File outfile) throws Exception {
         ClassLoader  cl  = Thread.currentThread().getContextClassLoader();
@@ -282,7 +287,7 @@ public class App {
 
         String dir_l  = (localrepo == null)
             ? "boot/default"
-            : "boot/custom" + (new File(localrepo)).getCanonicalFile().getPath();
+            : "boot/custom/" + md5hash((new File(localrepo)).getCanonicalFile().getPath());
         
         if (clj_v != null) cljversion = clj_v;
         if (boot_v != null) bootversion = boot_v;


### PR DESCRIPTION
use md5 hash when building path components when the environment variable
BOOT_LOCAL_REPO is set.

Previously we ended up trying to use illegal filenames like
C:\home\.boot\cache\boot\customC:\home\.m2\... on windows.

We now use a single directory under boot/custom/ instead of a deep
directory structure.

The conversion to a hex string is a bit awkward, see
https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java
for a discussion.

fixes https://github.com/boot-clj/boot/issues/243