### PR TITLE
Make Clojure artifact name customizable via BOOT_CLOJURE_NAME

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -106,9 +106,11 @@
   It returns a Java array of java.io.File objects corresponding to the resolved
   dependencies."
   ([env] (->> env resolve-dependencies (map :jar)))
-  ([sym-str version cljversion]
-     (->> {:dependencies [['org.clojure/clojure cljversion] [(symbol sym-str) version]]}
-       resolve-dependencies (map (comp io/file :jar)) (into-array java.io.File))))
+  ([sym-str version cljversion] (resolve-dependency-jars sym-str version nil cljversion))
+  ([sym-str version cljname cljversion]
+     (let [cljname (or cljname "org.clojure/clojure")]
+       (->> {:dependencies [[(symbol cljname) cljversion] [(symbol sym-str) version]]}
+            resolve-dependencies (map (comp io/file :jar)) (into-array java.io.File)))))
 
 (defn resolve-nontransitive-dependencies
   "Given an env map and a single dependency coordinates vector, resolves the

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -30,6 +30,7 @@
           opts  (->> main/cli-opts (mapv (fn [[x y z]] ["" (str x " " y) z])))
           envs  [["" "BOOT_AS_ROOT"            "Set to 'yes' to allow boot to run as root."]
                  ["" "BOOT_CLOJURE_VERSION"    "The version of Clojure boot will provide (1.7.0)."]
+                 ["" "BOOT_CLOJURE_NAME"       "The artefact name of Clojure boot will provide (org.clojure/clojure)."]
                  ["" "BOOT_HOME"               "Directory where boot stores global state (~/.boot)."]
                  ["" "BOOT_FILE"               "Build script name (build.boot)."]
                  ["" "BOOT_JAVA_COMMAND"       "Specify the Java executable (java)."]

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -455,8 +455,9 @@
   ([] (init-pod! env (boot.App/newPod)))
   ([{:keys [directories dependencies] :as env}]
      (let [dirs (map io/file directories)
+           cljname (or (boot.App/getClojureName) "org.clojure/clojure")
            dfl  [['boot/pod (boot.App/getBootVersion)]
-                 ['org.clojure/clojure (clojure-version)]]
+                 [(symbol cljname) (clojure-version)]]
            env  (default-dependencies dfl env)
            jars (resolve-dependency-jars env)
            urls (concat dirs jars)]


### PR DESCRIPTION
Make Clojure artifact name customizable via BOOT_CLOJURE_NAME environment variable, which defaults to org.clojure/clojure.

This allows e.g. to run REPL or AOT with custom clojure forks like Dunaj, Skummet or companies' private ones.