### PR TITLE
Stop 'boot show -u' from displaying "LATEST" dependencies as out of date

### DIFF
--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -255,7 +255,8 @@
   [env & {:keys [snapshots]}]
   (with-call-worker (boot.aether/update-always!))
   (let [v+ (if snapshots "(0,)" "RELEASE")]
-    (->> (for [[p v & _ :as coord] (->> env :dependencies (map canonical-coord))]
+    (->> (for [[p v & _ :as coord] (->> env :dependencies (map canonical-coord))
+                                   :when (not (= v "LATEST"))]
            (util/guard
              (let [env' (-> env (assoc :dependencies [(assoc coord 1 v+)]))
                    [p' v' & _ :as coord'] (->> (map :dep (resolve-dependencies env'))


### PR DESCRIPTION
Currently 'boot show -u' will treat any dependencies with the version "LATEST" as out-of-date and display the latest available version. This removes any dependencies with a version "LATEST" from the version check.