### PR TITLE
New implementation for signing releases

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -693,9 +693,6 @@
   [f file PATH            str      "The jar file to deploy."
    F file-regex MATCH     #{regex} "The set of regexes of paths to deploy."
    g gpg-sign             bool     "Sign jar using GPG private key."
-   k gpg-user-id NAME     str      "The name used to find the GPG key."
-   K gpg-keyring PATH     str      "The path to secring.gpg file to use for signing."
-   p gpg-passphrase PASS  str      "The passphrase to unlock GPG signing key."
    r repo ALIAS           str      "The alias of the deploy repository."
    t tag                  bool     "Create git tag for this version."
    B ensure-branch BRANCH str      "The required current git branch."
@@ -726,7 +723,7 @@
                   snapshot?    (.endsWith v "-SNAPSHOT")
                   artifact-map (when gpg-sign
                                  (util/info "Signing %s...\n" (.getName f))
-                                 (helpers/sign-jar tgt f gpg-passphrase gpg-keyring gpg-user-id))]
+                                 (helpers/sign-jar tgt f))]
               (assert (or (not ensure-branch) (= b ensure-branch))
                       (format "current git branch is %s but must be %s" b ensure-branch))
               (assert (or (not ensure-clean) clean?)

--- a/boot/core/src/boot/task_helpers.clj
+++ b/boot/core/src/boot/task_helpers.clj
@@ -35,21 +35,11 @@
         (->> sym ns-aliases (into base) (mapcat pubs)))
       (filter task?) (sort-by :name) (group-by :ns*) (into (sorted-map)))))
 
-(defn read-pass
-  [prompt]
-  (String/valueOf (.readPassword (System/console) prompt nil)))
-
-(defn sign-jar [out jar pass keyring user-id]
-  (let [prompt (pod/with-call-worker
-                 (boot.pgp/prompt-for ~keyring ~user-id))
-        pass   (or pass (read-pass prompt))]
-    (pod/with-call-worker
-      (boot.pgp/sign-jar
-        ~(.getPath out)
-        ~(.getPath jar)
-        ~pass
-        :keyring ~keyring
-        :user-id ~user-id))))
+(defn sign-jar [out jar]
+  (pod/with-call-worker
+    (boot.pgp/sign-jar
+     ~(.getPath out)
+     ~(.getPath jar))))
 
 (defn print-fileset
   [fileset]

--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -25,7 +25,7 @@
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]
                  [javazoom/jlayer             "1.0.1"]
-                 [mvxcvi/clj-pgp              "0.5.4"]
+                 [mvxcvi/clj-pgp              "0.8.2"]
                  [net.java.dev.jna/jna        "4.1.0"]
                  [alandipert/desiderata       "1.0.2"]
                  [org.clojure/data.xml        "0.0.8"]

--- a/boot/worker/src/boot/pgp.clj
+++ b/boot/worker/src/boot/pgp.clj
@@ -2,56 +2,74 @@
   (:require
    [clojure.java.io   :as io]
    [boot.pod          :as pod]
-   [mvxcvi.crypto.pgp :as pgp])
+   (clj-pgp
+     [core :as pgp]
+     [keyring :as keyring]
+     [signature :as pgp-sig]))
   (:import
    [java.util.regex Pattern]
    [java.io StringBufferInputStream]))
 
-(def default-secring
-  (-> (System/getProperty "user.home")
-    (io/file ".gnupg" "secring.gpg")))
+(defn find-secring []
+  (let [home (System/getenv "HOME")
+        locations [(System/getenv "GNUPGHOME") (System/getenv "BOOT_GPG_SECRING") (str home "/.gnupg/secring.gpg") (str home "/.gpg/secring.gpg")]
+        exists-fn #(when (and % (.exists (io/as-file %))) %)
+        secring (some exists-fn locations)]
+    (or secring (throw (Exception. "Can't find secring file. Please set 'BOOT_GPG_SECRING'")))))
 
-(defn secring
-  [& [file]]
-  (pgp/load-secret-keyring (io/file (or file default-secring))))
+(defn get-keyring []
+  (keyring/load-secret-keyring (io/file (find-secring))))
 
-(defn get-pubkey
-  [secring & [user]]
-  (let [ks      (pgp/list-public-keys secring)
-        re-user #(re-find (re-pattern (Pattern/quote (str user))) %)
-        match?  #(some re-user (-> % pgp/key-info :user-ids))]
-    (let [ks' (if-not user ks (filter match? ks))]
-      (if (or (not user) (<= (count ks') 1))
-        (first ks')
-        (throw (ex-info "multiple keys match"
-                 {:keys (mapv pgp/key-info ks')}))))))
+(defn find-master-key-by-user [user]
+  (let [keyring (get-keyring)
+        pub-keys (keyring/list-public-keys keyring)
+        re-user #(re-find (re-pattern user) %)
+        match?  #(some re-user (-> % pgp/key-info :user-ids))
+        key (some #(when (match? %) %) pub-keys)]
+    (or key (throw (Exception. (format "User %s not found" user))))))
 
-(defn secret-key-for
-  [secring pubkey]
-  (pgp/get-secret-key secring (pgp/key-id pubkey)))
+(defn find-master-key []
+  (if-let [user (System/getenv "BOOT_GPG_USER")]
+    (find-master-key-by-user user)
+    (let [keyring (get-keyring)
+          master-keys (filter (comp :master-key? pgp/key-info) (keyring/list-public-keys keyring))]
+      (cond
+        (= 0 (count master-keys)) (throw (Exception. "No master key found"))
+        (= 1 (count master-keys)) (first master-keys)
+        :else (throw (Exception. "Multiple master keys found. Please set 'BOOT_GPG_USER'"))))))
 
-(defn prompt-for
-  [keyring user-id]
-  (if-let [pk (-> keyring secring (get-pubkey user-id))]
-    (-> pk pgp/key-info :user-ids first (str "\nGPG passphrase: "))
-    (throw (Exception. (format "public key not found (%s)" user-id)))))
+(defn get-private-key-by-id [hex-id passphrase]
+  (let [keyring (get-keyring)
+        seckey (keyring/get-secret-key keyring hex-id)]
+    (pgp/unlock-key seckey passphrase)))
 
-(defn sign
-  [content passphrase & {:keys [keyring user-id]}]
-  (let [sr (secring keyring)
-        pk (get-pubkey sr user-id)
-        sk (secret-key-for sr pk)
-        pr (pgp/unlock-key sk passphrase)]
-    (-> content (pgp/sign :sha1 pr) pgp/encode-ascii)))
+(defn get-private-key [passphrase]
+  (let [keyring (get-keyring)]
+    (if-let [hex-id (System/getenv "BOOT_GPG_SIGNING_KEY_ID")]
+      (get-private-key-by-id hex-id passphrase)
+      (-> (find-master-key)
+          pgp/key-info
+          :key-id
+          (#(keyring/get-secret-key keyring %))
+          (pgp/unlock-key passphrase)))))
+
+(defn read-pass
+  [prompt]
+  (String/valueOf (.readPassword (System/console) prompt nil)))
+
+(defn sign [content]
+  (let [passphrase (read-pass (str "\nGPG passphrase: "))
+        pr (get-private-key passphrase)]
+    (-> content (pgp-sig/sign pr) pgp/encode-ascii)))
 
 (defn sign-jar
-  [outpath jarpath passphrase & {:keys [keyring user-id]}]
+  [outpath jarpath]
   (let [outdir  (doto (io/file outpath) .mkdirs)
         jarname (.getName (io/file jarpath))
         pomxml  (StringBufferInputStream. (pod/pom-xml jarpath))
         jarout  (io/file outdir (str jarname ".asc"))
         pomout  (io/file outdir (.replaceAll jarname "\\.jar$" ".pom.asc"))
-        sign-it #(sign % passphrase :keyring keyring :user-id user-id)]
+        sign-it #(sign %)]
     (spit pomout (sign-it pomxml))
     (spit jarout (sign-it (io/input-stream jarpath)))
     {[:extension "jar.asc"] (.getPath jarout)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.2.0
+version=2.2.1


### PR DESCRIPTION
* Client libraries like bootlaces should not have to configure anything.
* Signing and encrypting in Boot-clj works out of the box, with no configuration. This can be made to work because we are going to make assumptions about the end user's environment. In turn, those defaults will be capable of being overridden with environment variables.
* Secret keyring location is the default one ($HOME/.gnupg/secring.pgp). Can be overridden with BOOT_GPG_SECRING.
* Name/Email is the one we find. Provided the secret keyring has only one user, we can be sure that we have the correct one. If more than one are found, we throw an error. Name/Email can be set with BOOT_GPG_USER.
* Default signing key is the first one returned by (keyring/list-public-keys keyring). This will work on a straightforward GPG setup. If the user follows best practices and has derived subkeys from his master keypair, he can set those with BOOT_GPG_SIGNING_KEY_ID and BOOT_GPG_ENCRYPTING_KEY_ID.