### PR TITLE
Add `rebuild!` to manually trigger `watch` task

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -30,6 +30,7 @@
 (declare ^{:dynamic true :doc "Command line options for boot itself."}   *boot-opts*)
 (declare ^{:dynamic true :doc "Count of warnings during build."}         *warnings*)
 
+(def new-build-at "Latest build occured at time." (atom 0))
 (def last-file-change "Last source file watcher update time." (atom 0))
 
 ;; Internal helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -523,6 +524,11 @@
                     (when-not (empty? changed) (callback changed))
                     (recur (util/guard [(.take q)])))))))
           #(.invoke @pod/worker-pod "boot.watcher/stop-watcher" k)))))
+
+(defn rebuild!
+  "Manually trigger build watch."
+  []
+  (reset! new-build-at (System/currentTimeMillis)))
 
 (defn init!
   "Initialize the boot environment. This is normally run once by boot at


### PR DESCRIPTION
Per discussion with @micha in #boot, I've made an initial attempt at exposing a function to trigger the `watch` task. I added an `M` (manual) flag to the watch task that causes it to ignore the file watcher in favor of another target. It feels a bit rough to me, so any suggestions for improvement would be welcome.