### PR TITLE
Update to ShimDandy 1.2.0

### DIFF
--- a/boot/base/pom.in.xml
+++ b/boot/base/pom.in.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.projectodd.shimdandy</groupId>
       <artifactId>shimdandy-api</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -18,4 +18,4 @@
   :dependencies [[boot/base                               ~version :scope "provided"]
                  [org.clojure/clojure                     "1.6.0"  :scope "provided"]
                  [org.tcrawley/dynapath                   "0.2.3"  :scope "compile"]
-                 [org.projectodd.shimdandy/shimdandy-impl "1.1.0"  :scope "compile"]])
+                 [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]])

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -467,7 +467,7 @@
 (defn destroy-pod
   [pod]
   (when pod
-    (.invoke pod "clojure.core/shutdown-agents")
+    (.close pod)
     (.. pod getClassLoader close)))
 
 (defn pod-pool


### PR DESCRIPTION
1.2.0 removes an avenue for leaking memory, and provides a close method
to call `shutdown-agents` on your behalf.

This should address #268.