### PR TITLE
Fix issues with 2.4.0 release

### DIFF
--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -377,7 +377,7 @@ public class App {
 
     public static String
     readVersion() throws Exception {
-        Properties   p = new Properties();
+        Properties p = new Properties();
         try (InputStream in = resource("boot/base/version.properties")) {
             p.load(in); }
         return p.getProperty("version"); }

--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -138,9 +138,9 @@
     (io/make-parents dst-file)
     (when-not (.canWrite (io/file dst-par))
       (throw (ex-info (format "Can't write to directory (%s)." dst-par) {:dir dst-par})))
+    (when (.exists dst-file) (.delete dst-file))
     (if *hard-link*
-      (do (when (.exists dst-file) (.delete dst-file))
-          (hard-link src-file dst-file))
+      (hard-link src-file dst-file)
       (doto dst-file cp-src! (.setLastModified last-mod)))))
 
 (defn copy-files

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -238,8 +238,12 @@
   (with-call-worker (boot.aether/resolve-dependencies ~env)))
 
 (defn resolve-dependency-jars
-  [env]
-  (->> env resolve-dependencies (map (comp io/file :jar))))
+  [env & [ignore-clj?]]
+  (let [clj-dep (symbol (boot.App/config "BOOT_CLOJURE_NAME"))
+        rm-clj  (if-not ignore-clj?
+                  identity
+                  (partial remove #(= clj-dep (first (:dep %)))))]
+    (->> env resolve-dependencies rm-clj (map (comp io/file :jar)))))
 
 (defn resolve-nontransitive-dependencies
   [env dep]
@@ -281,7 +285,7 @@
 
 (defn add-dependencies
   [env]
-  (doseq [jar (resolve-dependency-jars env)] (add-classpath jar)))
+  (doseq [jar (resolve-dependency-jars env true)] (add-classpath jar)))
 
 (defn add-dependencies-in
   [pod env]

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.4.0
+version=2.4.1


### PR DESCRIPTION
- Need to delete files in the fileset dirs before writing to them
  because the underlying blob files are immutable.
- Remove BOOT_CLOJURE_NAME dependency before adding jars to the
  classpath--this is a workaround for a really weird issue:

      clojure.lang.ExceptionInfo: loader constraint violation:
      loader (instance of java/net/URLClassLoader) previously initiated
      loading for a different type with name "clojure/lang/Compiler$Expr"