### PR TITLE
update to tools.nrepl 0.2.12

### DIFF
--- a/boot/core/src/boot/repl.clj
+++ b/boot/core/src/boot/repl.clj
@@ -2,7 +2,7 @@
   (:require [boot.util :as util]))
 
 (def ^:dynamic *default-dependencies*
-  (atom '[[org.clojure/tools.nrepl "0.2.8" :exclusions [[org.clojure/clojure]]]]))
+  (atom '[[org.clojure/tools.nrepl "0.2.12" :exclusions [[org.clojure/clojure]]]]))
 
 (def ^:dynamic *default-middleware*
   (atom (if-not @util/*colorize?* [] ['boot.from.io.aviso.nrepl/pretty-middleware])))


### PR DESCRIPTION
In contrast to 0.2.8 this version supports evaluation of forms containing reader conditionals.

Workaround until merged: `~/.boot/profile.boot`
```clojure
(reset! boot.repl/*default-dependencies*
        '[[org.clojure/tools.nrepl "0.2.11" :exclusions [[org.clojure/clojure]]]])
```