### PR TITLE
Convert url only repos to maps in push task

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -19,8 +19,8 @@
 (def offline?             (atom false))
 (def update?              (atom :daily))
 (def local-repo           (atom nil))
-(def default-repositories (atom [["clojars"       "https://clojars.org/repo/"]
-                                 ["maven-central" "https://repo1.maven.org/maven2/"]]))
+(def default-repositories (atom [["clojars"       {:url "https://clojars.org/repo/"}]
+                                 ["maven-central" {:url "https://repo1.maven.org/maven2/"}]]))
 
 (defn set-offline!    [x] (reset! offline? x))
 (defn set-update!     [x] (reset! update? x))

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -45,8 +45,8 @@
 (def ^:private tempdirs-lock     (Semaphore. 1 true))
 (def ^:private src-watcher       (atom (constantly nil)))
 (def ^:private repo-config-fn    (atom identity))
-(def ^:private default-repos     [["clojars"       "https://clojars.org/repo/"]
-                                  ["maven-central" "https://repo1.maven.org/maven2"]])
+(def ^:private default-repos     [["clojars"       {:url "https://clojars.org/repo/"}]
+                                  ["maven-central" {:url "https://repo1.maven.org/maven2"}]])
 
 (def ^:private masks
   {:user     {:user true}


### PR DESCRIPTION
Repositories can be defined as maps or as urls. Default Clojars repo is
defined as a url. The string containing the url can't be merged with
`repo-map`. This change adds the same logic to push task as is used in
aether code to convert urls to maps.

Fixes #358