### PR TITLE
Checkout task - Remove existing deps

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -97,11 +97,15 @@
         names (map (memfn getName) jars)
         dirs  (map (memfn getParent) jars)
         tmps  (reduce #(assoc %1 %2 (core/tmp-dir!)) {} names)
-        adder #(core/add-source %1 %2 :exclude pod/standard-jar-exclusions)]
+        adder #(core/add-source %1 %2 :exclude pod/standard-jar-exclusions)
+        not-checkout? (fn [[proj ver]]
+                        (let [keyset (map first dependencies)]
+                         (not (contains? (into #{} keyset) proj))))]
     (when (seq deps)
       (util/info "Adding checkout dependencies:\n")
       (doseq [dep deps]
         (util/info "\u2022 %s\n" (pr-str dep))))
+    (core/set-env!   :dependencies #(into (vec (filter not-checkout? %)) (vec dependencies)))
     (core/merge-env! :dependencies (vec deps)
                      :source-paths (set dirs))
     (core/cleanup (core/set-env! :source-paths #(apply disj % dirs)))

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -99,15 +99,13 @@
         tmps  (reduce #(assoc %1 %2 (core/tmp-dir!)) {} names)
         adder #(core/add-source %1 %2 :exclude pod/standard-jar-exclusions)
         not-checkout? (fn [[proj ver]]
-                        (let [keyset (map first dependencies)]
-                         (not (contains? (into #{} keyset) proj))))]
+                        (not (contains? (into #{} (map first dependencies)) proj)))]
     (when (seq deps)
       (util/info "Adding checkout dependencies:\n")
       (doseq [dep deps]
         (util/info "\u2022 %s\n" (pr-str dep))))
-    (core/set-env!   :dependencies #(into (vec (filter not-checkout? %)) (vec dependencies)))
-    (core/merge-env! :dependencies (vec deps)
-                     :source-paths (set dirs))
+    (core/set-env!   :dependencies #(into (vec (filter not-checkout? %)) (vec deps)))
+    (core/merge-env! :source-paths (set dirs))
     (core/cleanup (core/set-env! :source-paths #(apply disj % dirs)))
     (core/with-pre-wrap [fs]
       (let [diff (->> (core/fileset-diff @prev fs)


### PR DESCRIPTION
When adding checkout dependencies, task should remove existing dependencies of the same symbol.