### PR TITLE
Add option to show task to verify deps [#375]

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -148,13 +148,90 @@
   [env]
   (->> env jars-dep-graph ksort/topo-sort reverse))
 
+(defn dep-spec->map [dep]
+  (let [[name version & rest] dep
+        meta (apply hash-map rest)]
+    (assoc meta :name name :version version)))
+
+(defn map->dep-spec [{:keys [name version] :as m}]
+  (into [name version] (apply concat (dissoc m :name :version))))
+
+(declare check-signature)
+
+(defn- ^{:boot/from :technomancy/leiningen} fetch-key
+  [signature err]
+  (if (or (re-find #"Can't check signature: public key not found" err)
+        (re-find #"Can't check signature: No public key" err))
+    (let [key (second (re-find #"using \w+ key ID (.+)" err))
+          {:keys [exit]} (gpg/gpg "--recv-keys" "--" key)]
+      (if (zero? exit)
+        (check-signature signature)
+        :no-key))
+    :bad-sig))
+
+(defn- ^{:boot/from :technomancy/leiningen} check-signature
+  [signature]
+  (let [{:keys [err exit]} (gpg/gpg "--verify" "--" (str signature))]
+    (if (zero? exit)
+      :signed ; TODO distinguish between signed and trusted
+      (fetch-key signature err))))
+
+(defn ignore-checksum [[name settings]]
+  [name (assoc
+          (if (string? settings) {:url settings} settings)
+          :checksum :ignore)])
+
+(defn ^{:boot/from :technomancy/leiningen} get-signature
+  ;; TODO: check pom signature too
+  [dep {:keys [repositories mirrors]}]
+  (try
+    (->> (aether/resolve-dependencies
+           :repositories (map ignore-checksum repositories)
+           :mirrors      mirrors
+           :coordinates  [(-> dep
+                            dep-spec->map
+                            (assoc :extension "jar.asc")
+                            map->dep-spec)])
+      (aether/dependency-files)
+      (filter #(.endsWith (.getName %) ".asc"))
+      (first))
+    (catch DependencyResolutionException _)))
+
+(def verify-colors {:signed   ansi/bold-cyan
+                    :unsigned ansi/bold-red
+                    :no-key   ansi/bold-yellow
+                    :bad-sig  ansi/bold-yellow})
+
+(defn verify-dep [env dep]
+  (vary-meta dep #(assoc %
+                    :verification (if-let [signature (get-signature dep env)]
+                                    (check-signature signature)
+                                    :unsigned))))
+
+(defn map-tree [f tree]
+  (map (fn [[parent children]]
+         [(f parent) (map-tree f children)]) tree))
+
+(defn- verify-deps [tree env]
+  (map-tree (partial verify-dep env) tree))
+
+(defn sig-status-prefix [dep]
+  (when-let [verification (:verification (meta dep))]
+    ((verify-colors verification) (format "%-9s " verification))))
+
+(defn colorize-dep [dep]
+  (if-let [verification (:verification (meta dep))]
+    ((verify-colors verification) (pr-str dep))
+    (pr-str dep)))
+
 (defn dep-tree
   "Returns the printed dependency graph as a string."
-  [env]
-  (->> env
+  [env & [verify?]]
+  (-> env
     resolve-dependencies-memoized*
-    (aether/dependency-hierarchy (:dependencies env))
-    util/print-tree
+    (->> (aether/dependency-hierarchy (:dependencies env)))
+    (cond-> verify? (verify-deps env))
+    (util/print-tree (when verify? sig-status-prefix) colorize-dep)
     with-out-str))
 
 (defn- pom-xml-parse-string

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -173,7 +173,8 @@
    p pedantic         bool  "Print graph of dependency conflicts."
    P pods REGEX       regex "The name filter used to select which pods to inspect."
    U update-snapshots bool  "Include snapshot versions in updates searches."
-   u updates          bool  "Print newer releases of outdated dependencies."]
+   u updates          bool  "Print newer releases of outdated dependencies."
+   v verify-deps      bool  "Include signature status of each dependency in graph."]
 
   (let [usage      (delay (*usage*))
         pretty-str #(with-out-str (pp/pprint %))
@@ -194,11 +195,11 @@
                                 (core/get-env)
                                 (pod/with-eval-in p boot.pod/env))]
                   (when pods (util/info "\nPod: %s\n\n" pod-name))
-                  (cond deps     (print (pod/with-call-worker (boot.aether/dep-tree ~pod-env)))
-                        env      (println (pretty-str (assoc pod-env :config (boot.App/config))))
-                        updates  (mapv prn (pod/outdated pod-env :snapshots update-snapshots))
-                        pedantic (pedantic/prn-conflicts pod-env)
-                        :else    @usage))))))))
+                  (cond (or deps verify-deps) (print (pod/with-call-worker (boot.aether/dep-tree ~pod-env ~verify-deps)))
+                        env                   (println (pretty-str (assoc pod-env :config (boot.App/config))))
+                        updates               (mapv prn (pod/outdated pod-env :snapshots update-snapshots))
+                        pedantic              (pedantic/prn-conflicts pod-env)
+                        :else                 @usage))))))))
 
 (core/deftask wait
   "Wait before calling the next handler.


### PR DESCRIPTION
This also enhances `boot.util/print-tree` to allow per-node prefixing
and custom node display.