### PR TITLE
Normalize paths matched by match-filter?

### DIFF
--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -3,7 +3,8 @@
    [clojure.java.io  :as io]
    [clojure.set      :as set]
    [clojure.data     :as data]
-   [boot.from.digest :as digest])
+   [boot.from.digest :as digest]
+   [clojure.string   :as str])
   (:import
    [java.net URI]
    [java.io File]
@@ -232,7 +233,8 @@
 
 (defn match-filter?
   [filters f]
-  ((apply some-fn (map (partial partial re-find) filters)) (.getPath ^File f)))
+  (letfn [(normalize [path] (str/replace path #"\\" "/"))]
+    ((apply some-fn (map (partial partial re-find) filters)) (normalize (.getPath ^File f)))))
 
 (defn keep-filters?
   [include exclude f]

--- a/boot/pod/test/boot/file_test.clj
+++ b/boot/pod/test/boot/file_test.clj
@@ -36,3 +36,12 @@
   (testing "Two absolute paths"
     (is (= "js/test.js"                (str (relative-to abs-dir  (io/file "/foo/bar/js/test.js"))))))
   )
+
+(deftest match-filter?-test
+  (let [filters #{#"^META-INF/MANIFEST.MF$"}]
+    (testing "Unix-style paths"
+      (is (match-filter? filters (io/file "META-INF/MANIFEST.MF"))))
+    (testing "Windows-style paths"
+      (is (match-filter? filters (io/file "META-INF\\MANIFEST.MF"))))
+    (testing "Sanity check for failure"
+      (is (not (match-filter? filters (io/file "META-INF/MANIFEST.NO")))))))


### PR DESCRIPTION
This is meant to fix #316.

One key use of match-filter? is from the standard-jar-exclusions
used in an uberjar build. On Windows these don't correctly  match
and exclude the MANIFEST and other files that are intended.

Normalizing paths in here to always use forward-slashes can avoid
this.