### PR TITLE
Support SSL certificates for repositories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2.5.6
+
+- Support SSL certificates for repositories [#380][380].
+
+## 2.5.5
+
+???
+
 ## 2.5.4
 
 #### Fixed

--- a/boot/aether/project.clj
+++ b/boot/aether/project.clj
@@ -16,4 +16,6 @@
   :dependencies [[org.clojure/clojure      "1.6.0"  :scope "compile"]
                  [boot/base                ~version :scope "provided"]
                  [boot/pod                 ~version :scope "compile"]
-                 [com.cemerick/pomegranate "0.3.0"  :scope "compile"]])
+                 [com.cemerick/pomegranate "0.3.0"  :scope "compile"]
+                 ;; updated wagon-http to lein's version, so the code could port
+                 [org.apache.maven.wagon/wagon-http "2.9"]])

--- a/boot/aether/project.clj
+++ b/boot/aether/project.clj
@@ -13,9 +13,8 @@
   :repositories [["clojars" {:url "https://clojars.org/repo" :creds :gpg :sign-releases false}]]
   :license      {:name "Eclipse Public License"
                  :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure      "1.6.0"  :scope "compile"]
-                 [boot/base                ~version :scope "provided"]
-                 [boot/pod                 ~version :scope "compile"]
-                 [com.cemerick/pomegranate "0.3.0"  :scope "compile"]
-                 ;; updated wagon-http to lein's version, so the code could port
-                 [org.apache.maven.wagon/wagon-http "2.9"]])
+  :dependencies [[org.clojure/clojure               "1.6.0"  :scope "compile"]
+                 [boot/base                         ~version :scope "provided"]
+                 [boot/pod                          ~version :scope "compile"]
+                 [com.cemerick/pomegranate          "0.3.0"  :scope "compile"]
+                 [org.apache.maven.wagon/wagon-http "2.9"    :scope "compile"]])

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -299,7 +299,7 @@
   (pod/add-dependencies (assoc env :dependencies [coord]))
   (load-wagon-mappings mapping))
 
-(defn load-certificates!
+(defn ^{:boot/from :technomancy/leiningen} load-certificates!
   "Load the SSL certificates specified by the project and register them for use by Aether."
   [certificates]
   (when (seq certificates)

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -298,3 +298,18 @@
   [env coord & [mapping]]
   (pod/add-dependencies (assoc env :dependencies [coord]))
   (load-wagon-mappings mapping))
+
+(defn load-certificates!
+  "Load the SSL certificates specified by the project and register them for use by Aether."
+  [certificates]
+  (when (seq certificates)
+    ;; lazy-loading might give a launch speed boost here
+    (require 'boot.ssl)
+    (let [make-context (resolve 'boot.ssl/make-sslcontext)
+          read-certs (resolve 'boot.ssl/read-certs)
+          default-certs (resolve 'boot.ssl/default-trusted-certs)
+          override-wagon-registry! (resolve 'boot.ssl/override-wagon-registry!)
+          https-registry (resolve 'boot.ssl/https-registry)
+          certs (mapcat read-certs certificates)
+          context (make-context (into (default-certs) certs))]
+      (override-wagon-registry! (https-registry context)))))

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -313,3 +313,7 @@
           certs (mapcat read-certs certificates)
           context (make-context (into (default-certs) certs))]
       (override-wagon-registry! (https-registry context)))))
+
+(when-let [certs (seq (string/split ":" (boot.App/config "BOOT_CERTIFICATES")))]
+  (util/dbug "Using SSL certificates: %s\n" certs)
+  (load-certificates! certs))

--- a/boot/aether/src/boot/ssl.clj
+++ b/boot/aether/src/boot/ssl.clj
@@ -23,7 +23,7 @@
   (doto (TrustManagerFactory/getInstance "PKIX")
     (.init keystore)))
 
-(defn default-trust-managers []
+(defn ^{:boot/from :technomancy/leiningen} default-trust-managers []
   (let [tmf (trust-manager-factory nil)
         tms (.getTrustManagers tmf)]
     (filter #(instance? X509TrustManager %) tms)))
@@ -37,7 +37,7 @@
            ;; TODO: support custom key-manager-properties
            {})))
 
-(defn key-manager-factory [{:keys [file type provider password]}]
+(defn ^{:boot/from :technomancy/leiningen} key-manager-factory [{:keys [file type provider password]}]
   (let [type (or type (KeyStore/getDefaultType))
         fis (if-not (empty? file) (FileInputStream. file))
         pwd (and password (.toCharArray password))
@@ -50,12 +50,12 @@
             (KeyManagerFactory/getDefaultAlgorithm))
       (.init store pwd))))
 
-(defn default-trusted-certs
+(defn ^{:boot/from :technomancy/leiningen} default-trusted-certs
   "Lists the CA certificates trusted by the JVM."
   []
   (mapcat #(.getAcceptedIssuers %) (default-trust-managers)))
 
-(defn read-certs
+(defn ^{:boot/from :technomancy/leiningen} read-certs
   "Read one or more X.509 certificates in DER or PEM format."
   [f]
   (let [cf (CertificateFactory/getInstance "X.509")
@@ -63,7 +63,7 @@
     (prn in)
     (.generateCertificates cf in)))
 
-(defn make-keystore
+(defn ^{:boot/from :technomancy/leiningen} make-keystore
   "Construct a KeyStore that trusts a collection of certificates."
   [certs]
   (let [ks (KeyStore/getInstance "jks")]
@@ -72,7 +72,7 @@
       (.setEntry ks (str i) (KeyStore$TrustedCertificateEntry. cert) nil))
     ks))
 
-(defn make-sslcontext
+(defn ^{:boot/from :technomancy/leiningen} make-sslcontext
   "Construct an SSLContext that trusts a collection of certificates."
   [trusted-certs]
   (let [ks (make-keystore trusted-certs)
@@ -83,14 +83,14 @@
 
 (alter-var-root #'make-sslcontext memoize)
 
-(defn https-registry
+(defn ^{:boot/from :technomancy/leiningen} https-registry
   "Constructs a registry map that uses a given SSLContext for https."
   [context]
   (let [factory (SSLConnectionSocketFactory. context (BrowserCompatHostnameVerifier.))]
     {"https" factory
      "http" PlainConnectionSocketFactory/INSTANCE}))
 
-(defn- map->registry
+(defn- ^{:boot/from :technomancy/leiningen} map->registry
   "Creates a Registry based of the given map."
   [m]
   (let [rb (RegistryBuilder/create)]

--- a/boot/aether/src/boot/ssl.clj
+++ b/boot/aether/src/boot/ssl.clj
@@ -1,0 +1,106 @@
+(ns boot.ssl
+  (:require
+    [cemerick.pomegranate.aether :as aether]
+    [clojure.java.io :as io])
+  (:import
+    java.security.KeyStore
+    java.security.KeyStore$TrustedCertificateEntry
+    java.security.Security
+    java.security.cert.CertificateFactory
+    javax.net.ssl.KeyManagerFactory
+    javax.net.ssl.SSLContext
+    javax.net.ssl.TrustManagerFactory
+    javax.net.ssl.X509TrustManager
+    java.io.FileInputStream
+    org.apache.http.config.RegistryBuilder
+    org.apache.http.conn.socket.PlainConnectionSocketFactory
+    org.apache.http.conn.ssl.BrowserCompatHostnameVerifier
+    org.apache.http.conn.ssl.SSLConnectionSocketFactory
+    org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+    org.apache.maven.wagon.providers.http.HttpWagon))
+
+(defn ^TrustManagerFactory trust-manager-factory [^KeyStore keystore]
+  (doto (TrustManagerFactory/getInstance "PKIX")
+    (.init keystore)))
+
+(defn default-trust-managers []
+  (let [tmf (trust-manager-factory nil)
+        tms (.getTrustManagers tmf)]
+    (filter #(instance? X509TrustManager %) tms)))
+
+(defn key-manager-props []
+  (let [read #(java.lang.System/getProperty %)]
+    (merge {:file (read "javax.net.ssl.keyStore")
+            :type (read "javax.net.ssl.keyStoreType")
+            :provider (read "javax.net.ssl.keyStoreProvider")
+            :password (read "javax.net.ssl.keyStorePassword")}
+           ;; TODO: support custom key-manager-properties
+           {})))
+
+(defn key-manager-factory [{:keys [file type provider password]}]
+  (let [type (or type (KeyStore/getDefaultType))
+        fis (if-not (empty? file) (FileInputStream. file))
+        pwd (and password (.toCharArray password))
+        store (if provider
+                (KeyStore/getInstance type provider)
+                (KeyStore/getInstance type))]
+    (.load store fis pwd)
+    (when fis (.close fis))
+    (doto (KeyManagerFactory/getInstance
+            (KeyManagerFactory/getDefaultAlgorithm))
+      (.init store pwd))))
+
+(defn default-trusted-certs
+  "Lists the CA certificates trusted by the JVM."
+  []
+  (mapcat #(.getAcceptedIssuers %) (default-trust-managers)))
+
+(defn read-certs
+  "Read one or more X.509 certificates in DER or PEM format."
+  [f]
+  (let [cf (CertificateFactory/getInstance "X.509")
+        in (io/input-stream (or (io/resource f) (io/file f)))]
+    (prn in)
+    (.generateCertificates cf in)))
+
+(defn make-keystore
+  "Construct a KeyStore that trusts a collection of certificates."
+  [certs]
+  (let [ks (KeyStore/getInstance "jks")]
+    (.load ks nil nil)
+    (doseq [[i cert] (map vector (range) certs)]
+      (.setEntry ks (str i) (KeyStore$TrustedCertificateEntry. cert) nil))
+    ks))
+
+(defn make-sslcontext
+  "Construct an SSLContext that trusts a collection of certificates."
+  [trusted-certs]
+  (let [ks (make-keystore trusted-certs)
+        kmf (key-manager-factory (key-manager-props))
+        tmf (trust-manager-factory ks)]
+    (doto (SSLContext/getInstance "TLS")
+      (.init (.getKeyManagers kmf) (.getTrustManagers tmf) nil))))
+
+(alter-var-root #'make-sslcontext memoize)
+
+(defn https-registry
+  "Constructs a registry map that uses a given SSLContext for https."
+  [context]
+  (let [factory (SSLConnectionSocketFactory. context (BrowserCompatHostnameVerifier.))]
+    {"https" factory
+     "http" PlainConnectionSocketFactory/INSTANCE}))
+
+(defn- map->registry
+  "Creates a Registry based of the given map."
+  [m]
+  (let [rb (RegistryBuilder/create)]
+    (doseq [[scheme conn-sock-factory] m]
+      (.register rb scheme conn-sock-factory))
+    (.build rb)))
+
+(defn override-wagon-registry!
+  "Override the registry scheme used by the HTTP Wagon's Connection
+  manager (used for Aether)."
+  [registry]
+  (let [cm (PoolingHttpClientConnectionManager. (map->registry registry))]
+    (HttpWagon/setPoolingHttpClientConnectionManager cm)))

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -627,6 +627,7 @@
 (defmethod pre-env! :wagons         [key old new env] (add-wagon! old new env))
 (defmethod pre-env! :dependencies   [key old new env] (add-dependencies! old new env))
 (defmethod pre-env! :repositories   [key old new env] (->> new (mapv (fn [[k v]] [k (@repo-config-fn (canonical-repo v))]))))
+(defmethod pre-env! :certificates   [key old new env] (pod/with-call-worker (boot.aether/load-certificates! ~new)))
 
 (add-watch repo-config-fn (gensym) (fn [& _] (set-env! :repositories identity)))
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -118,6 +118,11 @@
             (pod/unpack-jar (.getPath file) tmp)))
         (->> tmps vals (reduce adder fs) core/commit!)))))
 
+;; Would prefer (set-env! :certificates), but haven't figured that out yet.
+(core/deftask cert
+  [f files VARS [str] "Certificate file paths"]
+  (pod/with-call-worker (boot.aether/load-certificates! ~files)))
+
 (core/deftask speak
   "Audible notifications during build.
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -34,6 +34,7 @@
     (let [tasks (#'helpers/available-tasks 'boot.user)
           opts  (->> main/cli-opts (mapv (fn [[x y z]] ["" (str x " " y) z])))
           envs  [["" "BOOT_AS_ROOT"              "Set to 'yes' to allow boot to run as root."]
+                 ["" "BOOT_CERTIFICATES"         "List of \":\" separated paths to certificate files."]
                  ["" "BOOT_CLOJURE_VERSION"      "The version of Clojure boot will provide (1.7.0)."]
                  ["" "BOOT_CLOJURE_NAME"         "The artifact name of Clojure boot will provide (org.clojure/clojure)."]
                  ["" "BOOT_COLOR"                "Set to 'no' to turn colorized output off."]

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -118,11 +118,6 @@
             (pod/unpack-jar (.getPath file) tmp)))
         (->> tmps vals (reduce adder fs) core/commit!)))))
 
-;; Would prefer (set-env! :certificates), but haven't figured that out yet.
-(core/deftask cert
-  [f files VARS [str] "Certificate file paths"]
-  (pod/with-call-worker (boot.aether/load-certificates! ~files)))
-
 (core/deftask speak
   "Audible notifications during build.
 


### PR DESCRIPTION
This feature is the only blocker to using `boot` for some projects currently, and if it's already supported I couldn't figure out how :smile: 

Ported code from [here]( https://github.com/technomancy/leiningen/blob/d701275464c185f4f22be58450b1af4b94a79836/leiningen-core/src/leiningen/core/ssl.clj)

~~Since you'd want to add these certs before the dependencies are added, makes more sense as an `add-env!` hook than a task, but starting with the simplest step first.~~ 

Switched

~~At first tried to build this as a plugin, but had trouble getting the worker pod to add dependencies.~~ 

Think it makes more sense to add to boot itself, to integrate with `set-env!` (and show up in `show -e`)