### PR TITLE
Adding transfer-listener on aether/deploy

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -276,6 +276,7 @@
        :coordinates  [project version]
        :jar-file     (io/file jarpath)
        :pom-file     (io/file pomfile)
+       :transfer-listener :stdout
        :artifact-map artifact-map
        :repository   {repo-id repo-settings}
        :local-repo   (or (:local-repo env) @local-repo nil)))))


### PR DESCRIPTION
When I deploy an artefact with the `push` task I would like to see progress logged to the console. Aether provides a `transfer-listener` for that. One was used in boot for resolving dependencies, see [resolve-dependencies*][rd].
For the `deploy` task this is easily solved by also registering a `transfer-listener` in [deploy][dp]. This PR adds `:transfer-listener` to `:stdout`. 

Open question: Is `:stdout` really the way you guys want to log [to the console] or shall it defer logging to a custom transfer listener as with [resolve-dependencies*][rd]?

[rd]: https://github.com/boot-clj/boot/blob/master/boot/aether/src/boot/aether.clj#L77
[dp]: https://github.com/instilled/boot/blob/deploy-logging/boot/aether/src/boot/aether.clj#L279
