### PR TITLE
Fix boot.task.built-in/sift :add-meta

### DIFF
--- a/boot/core/src/boot/task_helpers.clj
+++ b/boot/core/src/boot/task_helpers.clj
@@ -58,15 +58,15 @@
 
 (defn- sift-match
   [invert? regexes]
-  (->> (map #(partial re-find %) regexes)
-       (apply some-fn)
-       (comp (if invert? not identity))))
+  (fn [path tmpfile]
+    ((if-not invert? identity not)
+     (some #(re-find % path) regexes))))
 
 (defn- sift-meta
   [invert? kws]
-  (->> (map #(fn [x] (contains? (meta x) %)) kws)
-       (apply some-fn)
-       (comp (if invert? not identity))))
+  (fn [path tmpfile]
+    (some (comp (if-not invert? identity not)
+                (partial contains? kws)) (keys tmpfile))))
 
 (defn- sift-mv
   [rolekey invert? optargs]
@@ -74,7 +74,7 @@
     (let [match?  (sift-match invert? optargs)
           dir     (#'core/get-add-dir fileset #{rolekey})
           reducer (fn [xs k v]
-                    (->> (if-not (match? k) v (assoc v :dir dir))
+                    (->> (if-not (match? k v) v (assoc v :dir dir))
                          (assoc xs k)))]
       (->> (partial reduce-kv reducer {})
            (update-in fileset [:tree])))))
@@ -87,10 +87,11 @@
            (reduce #(tmpd/add %1 dir %2 nil) fileset)))))
 
 (defn- sift-filter
+  "Similar to filter, where match? is a predicate with signature [path tmpfile]."
   [match?]
-  (let [reducer (fn [xs k v] (if-not (match? k) xs (assoc xs k v)))]
+  (let [reducer (fn [xs k v] (if-not (match? k v) xs (assoc xs k v)))]
     (fn [fileset] (->> (partial reduce-kv reducer {})
-                       (update-in fileset [:tree])))))
+                      (update-in fileset [:tree])))))
 
 (defn- jar-path
   [sym]

--- a/boot/core/src/boot/task_helpers.clj
+++ b/boot/core/src/boot/task_helpers.clj
@@ -133,3 +133,12 @@
               fs (digest/md5 jar) (partial pod/unpack-jar jar)
               :include incl :exclude excl :mergers pod/standard-jar-mergers)))
         (reduce fileset args))))
+
+(defmethod sift-action :add-meta
+  [v? _ args]
+  (fn [fileset]
+    (let [[regex kw] (first args)
+          file-paths (filter (comp (if v? not identity)
+                                   (partial re-find regex)) (keys (:tree fileset)))]
+      (core/add-meta fileset (zipmap file-paths
+                                     (repeat {kw true}))))))


### PR DESCRIPTION
Hello @micha,
this PR does a bunch of thing, from the commit message:

- changes the match? function in sift-filter in order to accept path and tmpfile (before
    just the path was passed. It also introduces tests for sift :include and :with-meta.

- adds the missing :add-meta sift-action and tests it.

I would like you to have a look at the test as given that I do not know how to reset a fileset in the middle of a task, there is no way to execute all the tests in sequence...
The tests are executed with `boot test`, which just calls `boot integration-tests` on the shell.

Code here:
https://github.com/arichiardi/boot/blob/sift-fix-test/boot/core/test/build.boot#L14

I am available to rework parts of it of course after your advice.