### PR TITLE
Do not include POM artifacts in uberjar

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -487,6 +487,7 @@
         jars       (-> (core/get-env)
                        (update-in [:dependencies] (partial filter scope?))
                        pod/resolve-dependency-jars)
+        jars       (remove #(.endsWith (.getName %) ".pom") jars)
         exclude    (or exclude pod/standard-jar-exclusions)
         merge      (or merge pod/standard-jar-mergers)
         reducer    (fn [xs jar]


### PR DESCRIPTION
Implementation of uber task has been changed and #291 bug reemerged. After following patch POM artifacts are removed from the list of jars that are to be included in uberjar.