### PR TITLE
pom packaging type & aether extension

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -251,7 +251,7 @@
 (defn- jarpath-on-artifact-map
   "Infer packaging type from `jarpath` or `packaging` in pom and add it
    to `artefact-map` if a mapping for `jarpath` not already exists."
-  [artifact-map {:keys [project version packaging] :as pom} jarpath]
+  [artifact-map {:keys [project version packaging classifier] :as pom} jarpath]
   (if (some #{jarpath} (vals artifact-map))
     artifact-map
     (assoc
@@ -266,7 +266,9 @@
                      "war"
 
                      :else
-                     "jar"))
+                     "jar")
+
+        :classifier classifier)
       jarpath)))
 
 (defn install

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -102,7 +102,7 @@
     (map (fn [x] {:dep x :jar (dep->path x)}))))
 
 (defn resolve-dependency-jars
-  "Given an env map, resolves dependencies and returns a list of dependency jar 
+  "Given an env map, resolves dependencies and returns a list of dependency jar
   file paths.
 
   The 3-arity is used by boot.App to resolve dependencies for the core pods.
@@ -248,18 +248,41 @@
   [pom-str]
   (doto (File/createTempFile "pom" ".xml") (.deleteOnExit) (spit pom-str)))
 
+(defn- jarpath-on-artifact-map
+  "Infer packaging type from `jarpath` or `packaging` in pom and add it
+   to `artefact-map` if a mapping for `jarpath` not already exists."
+  [artifact-map {:keys [project version packaging] :as pom} jarpath]
+  (if (some #{jarpath} (vals artifact-map))
+    artifact-map
+    (assoc
+      artifact-map
+      (conj
+        [project version]
+        :extension (cond
+                     packaging
+                     packaging
+
+                     (.endsWith (str jarpath) "war")
+                     "war"
+
+                     :else
+                     "jar"))
+      jarpath)))
+
 (defn install
   ([env jarpath]
    (install env jarpath nil))
   ([env jarpath pompath]
-   (let [pom-str                   (pod/pom-xml jarpath pompath)
-         {:keys [project version]} (pom-xml-parse-string pom-str)
-         pomfile                   (pom-xml-tmp pom-str)]
+   (install env jarpath pompath nil))
+  ([env jarpath pompath artifact-map]
+   (let [pom-str                           (pod/pom-xml jarpath pompath)
+         {:keys [project version] :as pom} (pom-xml-parse-string pom-str)
+         pomfile                           (pom-xml-tmp pom-str)]
      (aether/install
-       :coordinates [project version]
-       :jar-file    (io/file jarpath)
-       :pom-file    (io/file pomfile)
-       :local-repo  (or (:local-repo env) @local-repo nil)))))
+       :coordinates  [project version]
+       :pom-file     (io/file pomfile)
+       :artifact-map (jarpath-on-artifact-map artifact-map pom jarpath)
+       :local-repo   (or (:local-repo env) @local-repo nil)))))
 
 (defn deploy
   ([env repo jarpath]
@@ -269,14 +292,13 @@
      (deploy env repo jarpath nil pom-or-artifacts)
      (deploy env repo jarpath pom-or-artifacts nil)))
   ([env [repo-id repo-settings] jarpath pompath artifact-map]
-   (let [pom-str                   (pod/pom-xml jarpath pompath)
-         {:keys [project version]} (pom-xml-parse-string pom-str)
-         pomfile                   (pom-xml-tmp pom-str)]
+   (let [pom-str                           (pod/pom-xml jarpath pompath)
+         {:keys [project version] :as pom} (pom-xml-parse-string pom-str)
+         pomfile                           (pom-xml-tmp pom-str)]
      (aether/deploy
        :coordinates  [project version]
-       :jar-file     (io/file jarpath)
        :pom-file     (io/file pomfile)
-       :artifact-map artifact-map
+       :artifact-map (jarpath-on-artifact-map artifact-map pom jarpath)
        :repository   {repo-id repo-settings}
        :local-repo   (or (:local-repo env) @local-repo nil)))))
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -321,6 +321,7 @@
   [p project SYM           sym         "The project id (eg. foo/bar)."
    v version VER           str         "The project version."
    d description DESC      str         "The project description."
+   P packaging STR         str         "The project packaging type, i.e. war, pom"
    u url URL               str         "The project homepage url."
    s scm KEY=VAL           {kw str}    "The project scm map (KEY is one of url, tag, connection, developerConnection)."
    l license NAME:URL      {str str}   "The map {name url} of project licenses."
@@ -331,7 +332,7 @@
         tag  (or (:tag scm) (util/guard (git/last-commit)))
         scm  (when scm (assoc scm :tag tag))
         deps (or dependencies (:dependencies (core/get-env)))
-        opts (assoc *opts* :scm scm :dependencies deps :developers developers)]
+        opts (assoc *opts* :scm scm :dependencies deps :developers developers :packaging (or packaging "jar"))]
     (when-not (and project version)
       (throw (Exception. "need project and version to create pom.xml")))
     (let [[gid aid] (util/extract-ids project)

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -321,6 +321,7 @@
   [p project SYM           sym         "The project id (eg. foo/bar)."
    v version VER           str         "The project version."
    d description DESC      str         "The project description."
+   c classifier STR        str         "The project classifier."
    P packaging STR         str         "The project packaging type, i.e. war, pom"
    u url URL               str         "The project homepage url."
    s scm KEY=VAL           {kw str}    "The project scm map (KEY is one of url, tag, connection, developerConnection)."
@@ -332,7 +333,12 @@
         tag  (or (:tag scm) (util/guard (git/last-commit)))
         scm  (when scm (assoc scm :tag tag))
         deps (or dependencies (:dependencies (core/get-env)))
-        opts (assoc *opts* :scm scm :dependencies deps :developers developers :packaging (or packaging "jar"))]
+        opts (assoc *opts*
+               :scm scm
+               :dependencies deps
+               :developers developers
+               :classifies classifier
+               :packaging (or packaging "jar"))]
     (when-not (and project version)
       (throw (Exception. "need project and version to create pom.xml")))
     (let [[gid aid] (util/extract-ids project)

--- a/boot/worker/src/boot/pom.clj
+++ b/boot/worker/src/boot/pom.clj
@@ -20,7 +20,7 @@
   artifactId connection description dependencies dependency exclusion
   exclusions developerConnection enabled groupId id license licenses
   modelVersion name email project scope tag url scm version comments
-  developer developers packaging)
+  developer developers packaging classifier)
 
 ;;; private ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -31,6 +31,7 @@
     {:project     (util/guard (if (= gid aid) (symbol aid) (symbol gid aid)))
      :version     (util/guard (xml1-> z :version text))
      :description (util/guard (xml1-> z :description text))
+     :classifier  (util/guard (xml1-> z :classifier text))
      :url         (util/guard (xml1-> z :url text))
      :scm         {:url (util/guard (xml1-> z :scm :url text))
                    :tag (util/guard (xml1-> z :scm :tag text))}}))
@@ -52,6 +53,7 @@
                  sd :developerConnection} :scm
                 ds :developers
                 u :url
+                c :classifier
                 deps :dependencies
                 :as env}]
   (let [[g a] (util/extract-ids p)
@@ -75,6 +77,8 @@
             (comments lc))))
       (when pkg
         (packaging pkg))
+      (when c
+        (classifier c))
       (when (or su st sc sd)
         (scm
           (when sc (connection sc))

--- a/boot/worker/src/boot/pom.clj
+++ b/boot/worker/src/boot/pom.clj
@@ -1,6 +1,6 @@
 (ns boot.pom
   (:refer-clojure :exclude [name])
-  (:require 
+  (:require
    [clojure.java.io      :as io]
    [boot.pod             :as pod]
    [boot.file            :as file]
@@ -20,7 +20,7 @@
   artifactId connection description dependencies dependency exclusion
   exclusions developerConnection enabled groupId id license licenses
   modelVersion name email project scope tag url scm version comments
-  developer developers)
+  developer developers packaging)
 
 ;;; private ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -44,6 +44,7 @@
 (defn pom-xml [{p :project
                 v :version
                 d :description
+                pkg :packaging
                 l :license
                 {su :url
                  st :tag
@@ -72,6 +73,8 @@
             (url      lu)
             (name     ln)
             (comments lc))))
+      (when pkg
+        (packaging pkg))
       (when (or su st sc sd)
         (scm
           (when sc (connection sc))

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.5.5
+version=2.5.6-SNAPSHOT


### PR DESCRIPTION
This enables pom to provide packaging type other than the default (jar) and modifies `aether/{deploy,install}` fns by adding :extension to jarpath in artifact-map based on either packaging type in pom or file extension. 