### PR TITLE
Unpeel ExecutionExceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 - `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
 - `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
 - `boot.pod/pod-name` &mdash; get/set the name of a pod
+- `-c`, `--checkouts` option / `:checkouts` env key &mdash; deeper integration
+  for checkout dependencies
+
+#### Deprecated
+
+- The `checkout` task, replaced by the `--checkouts` boot option
 
 ## 2.5.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,17 @@
 
 #### Added
 
+##### API Functions
+
 - `boot.pod/this-pod` &mdash; a `WeakReference` to the current pod
 - `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
 - `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
 - `boot.pod/pod-name` &mdash; get/set the name of a pod
 - `boot.pod/coord->map` &mdash; dependency vector to map helper function
 - `boot.pod/map->coord` &mdash; map to dependency vector helper function
+
+##### Boot Options
+
 - `-c`, `--checkouts` boot option / `:checkouts` env key &mdash; deeper
   integration for checkout dependencies
 - `-o`, `--offline` boot option &mdash; disable downloading Maven dependencies
@@ -26,10 +31,18 @@
 - `-U`, `--update-snapshot` boot option &mdash; updates boot to latest snapshot
   version
 - optional argument to `-u`, `--update` &mdash; sets global default boot version
+
+##### Task Options
+
 - `-v`, `--verify-deps` option to `show` task &mdash; verify jar signatures and
   show deps tree [#375][375]
+
+##### Boot Environment
+
 - wagon dependencies now accept a `:schemes` key &mdash; specify the handler
   classes for the wagon when the wagon jar has no `leiningen/wagons.clj` entry.
+- `BOOT_CLOJARS_MIRROR` &mdash; specify Maven mirror for Boot's own dependencies.
+- `BOOT_MAVEN_CENTRAL_MIRROR` &mdash; specify Maven mirror for Boot's own dependencies.
 
 #### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## 2.6.0
+
 ## 2.5.3
 
 #### Improved

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,10 @@
 
 #### Fixed
 
-- Don't set :update :always in aether when resolving Boot's own dependencies
+- Don't set `:update :always` in aether when resolving Boot's own dependencies
   unless Boot is being updated.
+- Correctly handle case when `:source-paths` or `:resource-paths` are set to
+  the empty set (`#{}`).
 
 #### Added
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,12 @@
 - `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
 - `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
 - `boot.pod/pod-name` &mdash; get/set the name of a pod
-- `-c`, `--checkouts` option / `:checkouts` env key &mdash; deeper integration
-  for checkout dependencies
-- `-U`, `--update-snapshot` option &mdash; updates boot to latest snapshot version
+- `-c`, `--checkouts` boot option / `:checkouts` env key &mdash; deeper
+  integration for checkout dependencies
+- `-o`, `--offline` boot option &mdash; disable downloading Maven dependencies
+  from remote repositories (doesn't apply to Boot's own dependencies)
+- `-U`, `--update-snapshot` boot option &mdash; updates boot to latest snapshot
+  version
 - optional argument to `-u`, `--update` &mdash; sets global default boot version
 - `-v`, `--verify-deps` option to `show` task &mdash; verify jar signatures and
   show deps tree [#375][375]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 - Call `boot.core/load-data-readers!` automatically when new dependencies are
   loaded via `boot.core/set-env!`.
 
+#### Fixed
+
+- Don't set :update :always in aether when resolving Boot's own dependencies
+  unless Boot is being updated.
+
 #### Added
 
 - `boot.pod/this-pod` &mdash; a `WeakReference` to the current pod

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 #### Improved
 
 - More efficient syncing of project directories with Boot's internal ones.
+- Call `boot.core/load-data-readers!` automatically when new dependencies are
+  loaded via `boot.core/set-env!`.
 
 #### Added
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - `boot.pod/pod-name` &mdash; get/set the name of a pod
 - `-c`, `--checkouts` option / `:checkouts` env key &mdash; deeper integration
   for checkout dependencies
+- `-U`, `--update-snapshot` option &mdash; updates boot to latest snapshot version
+- optional argument to `-u`, `--update` &mdash; sets global default boot version
 
 #### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 - optional argument to `-u`, `--update` &mdash; sets global default boot version
 - `-v`, `--verify-deps` option to `show` task &mdash; verify jar signatures and
   show deps tree [#375][375]
+- wagon dependencies now accept a `:schemes` key &mdash; specify the handler
+  classes for the wagon when the wagon jar has no `leiningen/wagons.clj` entry.
 
 #### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,6 @@
 #### Improved
 
 - More efficient syncing of project directories with Boot's internal ones.
-- Call `boot.core/load-data-readers!` automatically when new dependencies are
-  loaded via `boot.core/set-env!`.
 
 #### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2.6.0
 
+#### Improved
+
+- More efficient syncing of project directories with Boot's internal ones.
+
 #### Added
 
 - `boot.pod/this-pod` &mdash; a `WeakReference` to the current pod
@@ -12,7 +16,8 @@
   for checkout dependencies
 - `-U`, `--update-snapshot` option &mdash; updates boot to latest snapshot version
 - optional argument to `-u`, `--update` &mdash; sets global default boot version
-- `-v`, `--verify-deps` option to `show` task &mdash; verify jar signatures and show deps tree [#375][375]
+- `-v`, `--verify-deps` option to `show` task &mdash; verify jar signatures and
+  show deps tree [#375][375]
 
 #### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## 2.6.0
 
+#### Added
+
+- `boot.pod/this-pod` &mdash; a `WeakReference` to the current pod
+- `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
+- `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
+
 ## 2.5.3
 
 #### Improved

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
 - `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
 - `boot.pod/pod-name` &mdash; get/set the name of a pod
+- `boot.pod/coord->map` &mdash; dependency vector to map helper function
+- `boot.pod/map->coord` &mdash; map to dependency vector helper function
 - `-c`, `--checkouts` boot option / `:checkouts` env key &mdash; deeper
   integration for checkout dependencies
 - `-o`, `--offline` boot option &mdash; disable downloading Maven dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - `boot.pod/this-pod` &mdash; a `WeakReference` to the current pod
 - `boot.pod/with-invoke-in` &mdash; low-level invocation, no serialization
 - `boot.pod/with-invoke-worker` &mdash; as above but invokes in the worker pod
+- `boot.pod/pod-name` &mdash; get/set the name of a pod
 
 ## 2.5.3
 

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -94,12 +94,13 @@
   "Given an env map, returns a list of maps of the form
      {:dep [foo/bar \"1.2.3\"], :jar \"file:...\"}
    corresponding to the resolved dependencies (including transitive deps)."
-  [env]
-  (->> [:dependencies :repositories :local-repo :offline? :mirrors :proxy]
-    (select-keys env)
-    resolve-dependencies-memoized*
-    ksort/topo-sort
-    (map (fn [x] {:dep x :jar (dep->path x)}))))
+  [{:keys [checkouts] :as env}]
+  (let [checkouts (set (map first checkouts))]
+    (->> [:dependencies :repositories :local-repo :offline? :mirrors :proxy]
+         (select-keys env)
+         resolve-dependencies-memoized*
+         ksort/topo-sort
+         (keep (fn [[p :as x]] (when-not (checkouts p) {:dep x :jar (dep->path x)}))))))
 
 (defn resolve-dependency-jars
   "Given an env map, resolves dependencies and returns a list of dependency jar 

--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -5,6 +5,7 @@ package boot;
 import java.io.*;
 import java.nio.channels.FileLock;
 import java.nio.channels.FileChannel;
+import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Map;
@@ -314,6 +315,7 @@ public class App {
         rt.invoke("boot.pod/seal-app-classloader");
         rt.invoke("boot.pod/set-data!", data);
         rt.invoke("boot.pod/set-pods!", pods);
+        rt.invoke("boot.pod/set-this-pod!", new WeakReference<ClojureRuntimeShim>(rt));
 
         pods.put(rt, new Object());
         return rt; }

--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -40,6 +40,7 @@ public class App {
     private static String                   channel             = "RELEASE";
     private static String                   booturl             = "http://boot-clj.com";
     private static String                   githuburl           = "https://api.github.com/repos/boot-clj/boot/releases";
+    private static boolean                  update_always       = false;
     private static ClojureRuntimeShim       aethershim          = null;
     private static HashMap<String, File[]>  depsCache           = null;
 
@@ -371,7 +372,8 @@ public class App {
         shim.require("boot.aether");
         if (localrepo != null)
             shim.invoke("boot.aether/set-local-repo!", localrepo);
-        shim.invoke("boot.aether/update-always!");
+        if (update_always)
+            shim.invoke("boot.aether/update-always!");
         return (File[]) shim.invoke(
             "boot.aether/resolve-dependency-jars", sym, bootversion, cljname, cljversion); }
 
@@ -424,9 +426,10 @@ public class App {
 
     public static void
     updateBoot(File bootprops, String version, String chan) throws Exception {
-        bootversion  = version;
-        channel      = chan;
-        Properties p = writeProps(bootprops);
+        update_always = true;
+        bootversion   = version;
+        channel       = chan;
+        Properties p  = writeProps(bootprops);
         p.store(System.out, booturl); }
 
     public static void

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -22,7 +22,7 @@
     [java.io File]
     [java.net URLClassLoader URL]
     [java.lang.management ManagementFactory]
-    [java.util.concurrent LinkedBlockingQueue TimeUnit Semaphore]))
+    [java.util.concurrent LinkedBlockingQueue TimeUnit Semaphore ExecutionException]))
 
 (declare watch-dirs sync! post-env! get-env set-env! tmp-file tmp-dir ls empty-dir!)
 
@@ -855,10 +855,12 @@
   (try @(future ;; see issue #6
           (util/with-let [_ nil]
             (run-tasks
-              (cond (every? fn? argv)     (apply comp argv)
-                    (every? string? argv) (apply construct-tasks argv)
-                    :else (throw (IllegalArgumentException.
-                                   "Arguments must be either all strings or all fns"))))))
+             (cond (every? fn? argv)     (apply comp argv)
+                   (every? string? argv) (apply construct-tasks argv)
+                   :else (throw (IllegalArgumentException.
+                                 "Arguments must be either all strings or all fns"))))))
+       (catch ExecutionException e
+         (throw (.getCause e)))
        (finally (do-cleanup!))))
 
 ;; Low-Level Tasks, Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -56,6 +56,10 @@
 (def ^:private loaded-checkouts  (atom #{}))
 (def ^:private default-repos     [["clojars"       {:url "https://clojars.org/repo/"}]
                                   ["maven-central" {:url "https://repo1.maven.org/maven2"}]])
+(def ^:private default-mirrors   (delay (let [c (boot.App/config "BOOT_CLOJARS_MIRROR")
+                                              m (boot.App/config "BOOT_MAVEN_CENTRAL_MIRROR")
+                                              f #(when %1 {%2 {:name (str %2 " mirror") :url %1}})]
+                                          (merge {} (f c "clojars") (f m "maven-central")))))
 
 (def ^:private masks
   {:user     {:user true}
@@ -619,7 +623,8 @@
              :asset-paths      #{}
              :target-path      "target"
              :exclusions       #{}
-             :repositories     default-repos})
+             :repositories     default-repos
+             :mirrors          @default-mirrors})
     (add-watch ::boot #(configure!* %3 %4)))
   (set-fake-class-path!)
   (tmp-dir** nil :asset)

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -536,7 +536,7 @@
         (let [q       (LinkedBlockingQueue.)
               watcher (apply file/watcher! :time dirs)
               paths   (into-array String dirs)
-              k       (.invoke pod/worker-pod "boot.watcher/make-watcher" q paths)]
+              k       (pod/with-invoke-worker (boot.watcher/make-watcher q paths))]
           (daemon
             (loop [ret (util/guard [(.take q)])]
               (when ret
@@ -545,7 +545,7 @@
                   (let [changed (watcher)]
                     (when-not (empty? changed) (callback changed))
                     (recur (util/guard [(.take q)])))))))
-          #(.invoke pod/worker-pod "boot.watcher/stop-watcher" k)))))
+          #(pod/with-invoke-worker (boot.watcher/stop-watcher k))))))
 
 (defn rebuild!
   "Manually trigger build watch."

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -269,6 +269,7 @@
     (report-version-conflicts (find-version-conflicts old new env))
     (->> new (assoc env :dependencies) pod/add-dependencies)
     (add-checkout-dependencies! env)
+    (load-data-readers!)
     (set-fake-class-path!)
     new))
 

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -269,7 +269,6 @@
     (report-version-conflicts (find-version-conflicts old new env))
     (->> new (assoc env :dependencies) pod/add-dependencies)
     (add-checkout-dependencies! env)
-    (load-data-readers!)
     (set-fake-class-path!)
     new))
 

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -293,8 +293,10 @@
    (add-wagon! old new env nil))
   ([old new env scheme-map]
    (doseq [maven-coord new]
-     (pod/with-call-worker
-       (boot.aether/add-wagon ~env ~maven-coord ~scheme-map)))
+     (let [{:keys [schemes] :as coord-map} (pod/coord->map maven-coord)
+           maven-coord (pod/map->coord (dissoc coord-map :schemes))]
+       (pod/with-call-worker
+         (boot.aether/add-wagon ~env ~maven-coord ~(or scheme-map schemes)))))
    new))
 
 (defn- order-set-env-keys

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -776,10 +776,9 @@
   fileset containing only the latest project files."
   [& [fileset]]
   (let [fileset (when fileset (rm fileset (user-files fileset)))]
-    (sync-user-dirs!)
     (-> (new-fileset)
-        (add-user-asset (first (user-asset-dirs)))
-        (add-user-source (first (user-source-dirs)))
+        (add-user-asset    (first (user-asset-dirs)))
+        (add-user-source   (first (user-source-dirs)))
         (add-user-resource (first (user-resource-dirs)))
         (add-user-checkout (first (user-checkout-dirs)))
         (update-in [:tree] merge (:tree fileset)))))

--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -29,6 +29,7 @@
     :assoc-fn #(let [[k v] (string/split %3 #"=" 2)]
                  (update-in %1 [%2] (fnil assoc {}) (keyword k) v))]
    ["-h" "--help"                "Print basic usage and help info."]
+   ["-o" "--offline"             "Don't attempt to access remote repositories." :id :offline?]
    ["-P" "--no-profile"          "Skip loading of profile.boot script."]
    ["-r" "--resource-paths PATH" "Add PATH to set of resource directories."
     :assoc-fn #(update-in %1 [%2] (fnil conj #{}) %3)]
@@ -176,7 +177,7 @@
               localforms  (when profile?
                             (some->> localscript slurp util/read-string-all))
               initial-env (->> [:source-paths :resource-paths :asset-paths
-                                :target-path :dependencies :checkouts]
+                                :target-path :dependencies :checkouts :offline?]
                                (reduce #(if-let [v (opts %2)] (assoc %1 %2 v) %1) {})
                                (merge {} (:set-env opts)))
               import-ns   (export-task-namespaces initial-env)

--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -38,6 +38,7 @@
    ["-t" "--target-path PATH"    "Set the target directory to PATH."]
    ["-T" "--no-target"           "Don't automatically write files to the target directory."]
    ["-u" "--update"              "Update boot to latest release version."]
+   ["-U" "--update-snapshot"     "Update boot to latest snapshot version."]
    ["-v" "--verbose"             "More error info (-vv more verbose, etc.)"
     :assoc-fn (fn [x y _] (update-in x [y] (fnil inc 0)))]
    ["-V" "--version"             "Print boot version info."]])

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -34,6 +34,7 @@
     (let [tasks (#'helpers/available-tasks 'boot.user)
           opts  (->> main/cli-opts (mapv (fn [[x y z]] ["" (str x " " y) z])))
           envs  [["" "BOOT_AS_ROOT"              "Set to 'yes' to allow boot to run as root."]
+                 ["" "BOOT_CLOJARS_MIRROR"       "Specify mirror for clojars.org for boot's own dependencies."]
                  ["" "BOOT_CLOJURE_VERSION"      "The version of Clojure boot will provide (1.7.0)."]
                  ["" "BOOT_CLOJURE_NAME"         "The artifact name of Clojure boot will provide (org.clojure/clojure)."]
                  ["" "BOOT_COLOR"                "Set to 'no' to turn colorized output off."]
@@ -44,6 +45,7 @@
                  ["" "BOOT_JAVA_COMMAND"         "Specify the Java executable (java)."]
                  ["" "BOOT_JVM_OPTIONS"          "Specify JVM options (Unix/Linux/OSX only)."]
                  ["" "BOOT_LOCAL_REPO"           "The local Maven repo path (~/.m2/repository)."]
+                 ["" "BOOT_MAVEN_CENTRAL_MIRROR" "Specify mirror for repo1.maven.org for boot's own dependencies."]
                  ["" "BOOT_VERSION"              "Specify the version of boot core to use."]
                  ["" "BOOT_WARN_DEPRECATED"      "Set to 'no' to suppress deprecation warnings."]]
           files [["" "./boot.properties"         "Specify boot options for this project."]

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -651,19 +651,19 @@
       (core/empty-dir! tgt)
       (let [warname (or file "project.war")
             warfile (io/file tgt warname)
-            inf?    #(contains? #{"META-INF" "WEB-INF"} %)]
-        (let [->war   #(let [r    (core/tmp-path %)
-                             r'   (file/split-path r)
-                             path (->> (if (.endsWith r ".jar")
-                                         ["lib" (last r')]
-                                         (into ["classes"] r'))
-                                       (into ["WEB-INF"]))]
-                         (if (inf? (first r')) r (.getPath (apply io/file path))))
-              entries (core/output-files fs)
-              index   (->> entries (mapv (juxt ->war #(.getPath (core/tmp-file %)))))]
-          (util/info "Writing %s...\n" (.getName warfile))
-          (jar/spit-jar! (.getPath warfile) index {} nil)
-          (-> fs (core/add-resource tgt) core/commit!))))))
+            inf?    #(contains? #{"META-INF" "WEB-INF"} %)
+            ->war   #(let [r    (core/tmp-path %)
+                           r'   (file/split-path r)
+                           path (->> (if (.endsWith r ".jar")
+                                       ["lib" (last r')]
+                                       (into ["classes"] r'))
+                                     (into ["WEB-INF"]))]
+                       (if (inf? (first r')) r (.getPath (apply io/file path))))
+            entries (core/output-files fs)
+            index   (->> entries (mapv (juxt ->war #(.getPath (core/tmp-file %)))))]
+        (util/info "Writing %s...\n" (.getName warfile))
+        (jar/spit-jar! (.getPath warfile) index {} nil)
+        (-> fs (core/add-resource tgt) core/commit!)))))
 
 (core/deftask zip
   "Build a zip file for the project."

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -66,8 +66,8 @@
                    (map string/trimr)
                    (string/join "\n"))))))
 
-(core/deftask checkout
-  "Checkout dependencies task.
+(core/deftask ^{:deprecated "2.6.0"} checkout
+  "Checkout dependencies task. DEPRECATED.
 
   This task facilitates working on a project and its dependencies at the same
   time, by extracting the dependency jar contents into the fileset. Transitive
@@ -97,8 +97,12 @@
         names (map (memfn getName) jars)
         dirs  (map (memfn getParent) jars)
         tmps  (reduce #(assoc %1 %2 (core/tmp-dir!)) {} names)
+        warn  (delay
+                (util/warn-deprecated
+                  "The checkout task is deprecated. Please use the --checkouts boot option instead.\n"))
         adder #(core/add-source %1 %2 :exclude pod/standard-jar-exclusions)]
     (when (seq deps)
+      @warn
       (util/info "Adding checkout dependencies:\n")
       (doseq [dep deps]
         (util/info "\u2022 %s\n" (pr-str dep))))

--- a/boot/pod/src/boot/filesystem.clj
+++ b/boot/pod/src/boot/filesystem.clj
@@ -1,19 +1,27 @@
 (ns boot.filesystem
   (:require
-    [clojure.java.io :as io]
-    [boot.file       :as file]
-    [boot.util       :as util]
-    [boot.tmpdir     :as tmpd])
+    [clojure.java.io        :as io]
+    [clojure.set            :as set]
+    [clojure.data           :as data]
+    [boot.filesystem.patch  :as fsp]
+    [boot.file              :as file]
+    [boot.tmpdir            :as tmpd]
+    [boot.from.digest       :as digest :refer [md5]]
+    [boot.util              :as util   :refer [with-let]])
   (:import
-   [java.net URI]
-   [java.io File]
-   [java.nio.file.attribute FileAttribute FileTime]
-   [java.util.zip ZipEntry ZipOutputStream ZipException]
-   [java.util.jar JarEntry JarOutputStream Manifest Attributes$Name]
-   [java.nio.file Files FileSystems StandardCopyOption StandardOpenOption]))
+    [java.net URI]
+    [java.io File]
+    [java.nio.file.attribute FileAttribute FileTime]
+    [java.util.zip ZipEntry ZipOutputStream ZipException]
+    [java.util.jar JarEntry JarOutputStream Manifest Attributes$Name]
+    [java.nio.file Files FileSystems StandardCopyOption StandardOpenOption
+     LinkOption SimpleFileVisitor FileVisitResult]))
 
-(def copy-opts (into-array StandardCopyOption [StandardCopyOption/REPLACE_EXISTING]))
-(def open-opts (into-array StandardOpenOption [StandardOpenOption/CREATE]))
+(def continue     FileVisitResult/CONTINUE)
+(def skip-subtree FileVisitResult/SKIP_SUBTREE)
+(def link-opts    (into-array LinkOption []))
+(def copy-opts    (into-array StandardCopyOption [StandardCopyOption/REPLACE_EXISTING]))
+(def open-opts    (into-array StandardOpenOption [StandardOpenOption/CREATE]))
 
 (defn mkfs
   [^File rootdir]
@@ -31,6 +39,67 @@
     (.resolve fs (.toPath file))
     (let [[seg & segs] (file/split-path file)]
       (.getPath fs seg (into-array String segs)))))
+
+(defn mkignores
+  [ignores]
+  (some->> (seq ignores) (map #(partial re-find %)) (apply some-fn)))
+
+(defn mkvisitor
+  [root tree & {:keys [ignore]}]
+  (let [ign? (mkignores ignore)]
+    (proxy [SimpleFileVisitor] []
+      (preVisitDirectory [path attr]
+        (let [p (.relativize root path)]
+          (if (and ign? (ign? (.toString p))) skip-subtree continue)))
+      (visitFile [path attr]
+        (with-let [_ continue]
+          (let [p (.relativize root path)]
+            (when-not (and ign? (ign? (.toString p)))
+              (->> (.toMillis (Files/getLastModifiedTime path link-opts))
+                   (hash-map :path p :file path :time)
+                   (assoc! tree p)))))))))
+
+(defrecord FileSystemTree [tree])
+
+(defn mktree
+  ([] (FileSystemTree. nil))
+  ([root & {:keys [ignore]}]
+   (FileSystemTree.
+     (persistent!
+       (with-let [tree (transient {})]
+         (Files/walkFileTree root (mkvisitor root tree :ignore ignore)))))))
+
+(defn merge-trees
+  [{tree1 :tree} {tree2 :tree}]
+  (FileSystemTree. (merge tree1 tree2)))
+
+(defn tree-diff
+  [{t1 :tree :as before} {t2 :tree :as after}]
+  (let [reducer #(assoc %1 %2 (:time %3))
+        [d1 d2] (map (partial reduce-kv reducer {}) [t1 t2])
+        [x y _] (map (comp set keys) (data/diff d1 d2))]
+    {:adds (->> (set/difference   y x) (select-keys t2) (assoc after :tree))
+     :rems (->> (set/difference   x y) (select-keys t1) (assoc after :tree))
+     :chgs (->> (set/intersection x y) (select-keys t2) (assoc after :tree))}))
+
+(defn tree-patch
+  [before after link]
+  (let [writeop (if (= :all link) :link :write)
+        {:keys [adds rems chgs]} (tree-diff before after)]
+    (-> (->> rems :tree vals (map #(vector :delete (.toString (:path %)))))
+        (into (->> (for [x (->> adds :tree vals)]
+                     [writeop (.toString (:path x)) (.toFile (:file x)) (:time x)])))
+        (into (->> chgs :tree vals
+                   (map (fn [{:keys [path file time]}]
+                          (let [h1 (md5 (.toString file))
+                                h2 (md5 (.toString (get-in before [:tree path :file])))]
+                            (if (= h1 h2)
+                              [:touch (.toString path) time]
+                              [writeop (.toString path) (.toFile file) time])))))))))
+
+(defmethod fsp/patch FileSystemTree
+  [before after link]
+  (tree-patch before after link))
 
 (defn mkparents!
   [path]
@@ -73,12 +142,10 @@
       (.write writer os))))
 
 (defn patch!
-  [fs old-fs new-fs & {:keys [link]}]
-  (doseq [[op & [arg1 arg2]] (tmpd/patch old-fs new-fs :link link)]
-    (let [[p1 f1 t1] ((juxt tmpd/path tmpd/file tmpd/time) arg1)
-          [p2 f2 t2] (when arg2 ((juxt tmpd/path tmpd/file tmpd/time) arg2))]
-      (case op
-        :delete (delete! fs p1)
-        :write  (copy!   fs p1 f1 t1)
-        :link   (link!   fs p1 f1)
-        :touch  (touch!  fs p1 t1)))))
+  [fs before after & {:keys [link]}]
+  (doseq [[op path & [arg1 arg2]] (fsp/patch before after link)]
+    (case op
+      :delete (delete! fs path)
+      :write  (copy!   fs path arg1 arg2)
+      :link   (link!   fs path arg1)
+      :touch  (touch!  fs path arg1))))

--- a/boot/pod/src/boot/filesystem/patch.clj
+++ b/boot/pod/src/boot/filesystem/patch.clj
@@ -1,0 +1,4 @@
+(ns boot.filesystem.patch)
+
+(defmulti  patch (fn [before after link] (type (or before after))))
+(defmethod patch :default [_ _ _] nil)

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -149,6 +149,20 @@
   (let [[aid gid] (util/extract-ids project)]
     (io/resource (format "META-INF/maven/%s/%s/pom.properties" aid gid))))
 
+(defn coord->map
+  "Returns the map representation for the given dependency vector. The map
+  will include :project and :version keys in addition to any other keys in
+  the dependency vector (eg., :scope, :exclusions, etc)."
+  [[p v & more]]
+  (merge {:project p :version v} (apply hash-map more)))
+
+(defn map->coord
+  "Returns the dependency vector for the given map representation. The project
+  and version will be taken from the values of the :project and :version keys
+  and all other keys will be appended pairwise."
+  [{:keys [project version] :as more}]
+  (into [project version] (mapcat identity (dissoc more :project :version))))
+
 (defn dependency-pom-properties
   "Given a dependency coordinate of the form [id version ...], returns a
   Properties object corresponding to the dependency jar's pom.properties file."

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -321,6 +321,14 @@
   [[sym & args]]
   `(with-invoke-in worker-pod (~sym ~@args)))
 
+(defn pod-name
+  "Returns pod's name if called with one argument, sets pod's name to new-name
+  and returns new-name if called with two arguments."
+  ([pod]
+   (.getName pod))
+  ([pod new-name]
+   (.setName pod new-name) new-name))
+
 (defn call-in*
   "Low-level interface by which expressions are evaluated in other pods. The
   two-arity version is invoked in the caller with a pod instance and an expr
@@ -744,7 +752,7 @@
        (doto (->> (into-array java.io.File urls)
                   (boot.App/newShim nil data)
                   (init-pod! env))
-         (.setName (caller-namespace))))))
+         (pod-name (caller-namespace))))))
 
 (defn destroy-pod
   "Closes open resources held by the pod, making the pod eligible for GC."

--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -232,10 +232,11 @@
           {:keys [added removed changed]} (diff* prev this [:id :dir])]
       (util/dbug "Committing fileset...\n")
       (doseq [tmpf (set/union (ls removed) (ls changed))
-              :let [prev (get-in prev [:tree (path tmpf)])]]
-        (when (.exists ^File (file prev))
-          (util/dbug "Commit: removing %s %s...\n" (id prev) (path prev))
-          (file/delete-file (file prev))))
+              :let [prev (get-in prev [:tree (path tmpf)])
+                    exists? (.exists ^File (file prev))
+                    op (if exists? "removing" "no-op")]]
+        (util/dbug "Commit: %-8s %s %s...\n" op (id prev) (path prev))
+        (when exists? (file/delete-file (file prev))))
       (let [this (loop [this this
                         [tmpf & tmpfs]
                         (->> (set/union (ls added) (ls changed))

--- a/mkdocs
+++ b/mkdocs
@@ -11,6 +11,12 @@
 (defn -main [& _]
 
   (write-docs
+    :ns boot.task.built-in
+    :tag *boot-version*
+    :src "boot/core/src"
+    :doc "Boot built-in tasks.")
+
+  (write-docs
     :ns boot.util
     :tag *boot-version*
     :src "boot/pod/src"
@@ -76,7 +82,7 @@
       resolve-nontransitive-dependencies apply-exclusions apply-global-exclusions
       canonical-coord copy-dependency-jar-entries default-dependencies
       dependency-pom-properties dependency-pom-properties-map outdated
-      extract-ids jars-dep-graph jars-in-dep-order)
+      extract-ids jars-dep-graph jars-in-dep-order coord->map map->coord)
 
     (section
       "Jars"
@@ -95,12 +101,6 @@
     (section
       "Deprecated / Internal"
       set-pods! set-data! set-pod-id! set-worker-pod!))
-
-  (write-docs
-    :ns boot.task.built-in
-    :tag *boot-version*
-    :src "boot/core/src"
-    :doc "Boot built-in tasks.")
 
   (write-docs
     :ns boot.core

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.5.3
+version=2.6.0-SNAPSHOT


### PR DESCRIPTION
After discussion on Slack it emerged that it is necessary and robust to unpeel ExecutionExceptions
when dereffing a feature so that the App.Exit (or whatever) inside can be properly propagated.
   
After tracking down all the @ and deref, I came to the conclusion that only boot.core/boot, the
entry point of the execution, needs this.
    
This patch does exactly that.

(hopefully correctly)