### PR TITLE
target task: default output to :target-path if defined, otherwise "target"

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -217,7 +217,7 @@
   [d dir PATH #{str} "The set of directories to write to (target)."
    L no-link  bool   "Don't create hard links."
    C no-clean bool   "Don't clean target before writing project files."]
-  (let [dir   (or (seq dir) ["target"])
+  (let [dir   (or (seq dir) [(:target-path (core/get-env))] ["target"])
         sync! (#'core/fileset-syncer dir :clean (not no-clean))]
     (core/with-pass-thru [fs]
       (util/info "Writing target dir(s)...\n")


### PR DESCRIPTION
"target" is currently hardcoded in the target task.  This fixes that.  I don't really know how to do a proper pull request so let me know if I need to do something different.