### PR TITLE
Make the class paths be local to an environment

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -123,29 +123,42 @@
           (apply file/sync! :time (first d) s))))))
 
 (defn- set-fake-class-path!
-  "Sets the fake.class.path system property to reflect all JAR files on the
-  pod class path plus the :source-paths and :resource-paths. Note that these
-  directories are not actually on the class path (this is why it's the fake
-  class path). This property is a workaround for IDEs and tools that expect
-  the full class path to be determined by the java.class.path property.
+  "Sets the :fake-class-path environment property to reflect all JAR files on
+  the pod class path plus the :source-paths and :resource-paths. Note that
+  these directories are not actually on the class path (this is why it's the
+  fake class path). This property is a workaround for IDEs and tools that
+  expect the full class path to be determined by the java.class.path property.
 
-  Also sets the boot.class.path system property which is the same as above
+  Also sets the :boot-class-path environment property which is the same as above
   except that the actual class path directories are used instead of the user's
   project directories. This property can be used to configure Java tools that
   would otherwise be looking at java.class.path expecting it to have the full
   class path (the javac task uses it, for example, to configure the Java com-
-  piler class)."
+  piler class).
+
+  Also sets system properties fake.class.path and boot.class.path which mirror
+  their environment counterparts, but are updated jvm-wide when changed. They
+  are not reliable within a pod environment for this reason."
+
   []
-  (let [user-dirs  (->> (get-env)
-                        ((juxt :source-paths :resource-paths))
-                        (apply concat)
-                        (map #(.getAbsolutePath (io/file %))))
-        paths      (->> (pod/get-classpath) (map #(.getPath (URL. %))))
-        dir?       (comp (memfn isDirectory) io/file)
-        fake-paths (->> paths (remove dir?) (concat user-dirs))
-        separated  (partial string/join (System/getProperty "path.separator"))]
-    (System/setProperty "boot.class.path" (separated paths))
-    (System/setProperty "fake.class.path" (separated fake-paths))))
+  (let [user-dirs       (->> (get-env)
+                             ((juxt :source-paths :resource-paths))
+                             (apply concat)
+                             (map #(.getAbsolutePath (io/file %))))
+        paths           (->> (pod/get-classpath) (map #(.getPath (URL. %))))
+        dir?            (comp (memfn isDirectory) io/file)
+        fake-paths      (->> paths (remove dir?) (concat user-dirs))
+        separated       (partial string/join (System/getProperty "path.separator"))
+        boot-class-path (separated paths)
+        fake-class-path (separated fake-paths)]
+
+    (when (or (not= boot-class-path (get-env :boot-class-path))
+              (not= fake-class-path (get-env :fake-class-path)))
+      (set-env! :fake-class-path fake-class-path
+                :boot-class-path boot-class-path))
+    ;; Kept for backwards compatibility
+    (System/setProperty "boot.class.path" boot-class-path)
+    (System/setProperty "fake.class.path" fake-class-path)))
 
 (defn- set-user-dirs!
   "Resets the file watchers that sync the project directories to their

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -182,8 +182,8 @@
         sort-pods  #(sort-by (memfn getName) %)]
     (core/with-pass-thru [fs]
       (cond fileset        (helpers/print-fileset fs)
-            classpath      (println (or (System/getProperty "boot.class.path") ""))
-            fake-classpath (println (or (System/getProperty "fake.class.path") ""))
+            classpath      (println (or (core/get-env :boot-class-path) ""))
+            fake-classpath (println (or (core/get-env :fake-class-path) ""))
             list-pods      (doseq [p (->> pod/pods (map key) sort-pods)]
                              (println (.getName p)))
             :else
@@ -576,7 +576,7 @@
                           (throw (Exception. "The java compiler is not working. Please make sure you use a JDK!")))
             file-mgr  (.getStandardFileManager compiler diag-coll nil nil)
             opts      (->> ["-d"  (.getPath tgt)
-                            "-cp" (System/getProperty "boot.class.path")]
+                            "-cp" (core/get-env :boot-class-path)]
                            (concat options)
                            (into-array String) Arrays/asList)
             handler   {Diagnostic$Kind/ERROR util/fail

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.5.5
+version=2.5.6-fakeclasspath


### PR DESCRIPTION
This will allow repls that run in pods to have their classpath be accessible by external tools. Cider/Fireplace & co will need updating to use these new variables. Shouldn't be too difficult. The system setting remains as a fallback, but is unreliable, as it can be changed a lot within the lifecycle of a pod (by other pods), so can't be considered reliable.