### PR TITLE
Check that each keyword arg has a supplied value

### DIFF
--- a/boot/core/src/boot/cli.clj
+++ b/boot/core/src/boot/cli.clj
@@ -167,6 +167,8 @@
     (cond
       (nil? arg) split
       (not (keyword? arg)) (recur (update-in split [:cli] (fnil conj []) arg) more)
+      (empty? more) (update-in split [:errors] (fnil conj [])
+                               (str "no value supplied for option " arg))
       :else (recur (update-in split [:kw] assoc arg (first more)) (rest more)))))
 
 (defmacro ^:private assert
@@ -227,13 +229,13 @@
           clj-doc  (format "%s\n\nKeyword Args:\n%s\n" doc (clj-summary argspecs))
           varmeta  {:doc clj-doc :arglists arglists :argspec cli-args}]
       `(-> (fn [& args#]
-             (let [{kws# :kw clis# :cli} (#'split-args args#)
-                   [opts# args#] (#'separate-cli-opts clis# ~cli-args)
+             (let [split# (#'split-args args#)
+                   [opts# args#] (#'separate-cli-opts (:cli split#) ~cli-args)
                    parsed#   (cli/parse-opts opts# ~cli-args)
-                   ~bindings (merge kws# (:options parsed#))
+                   ~bindings (merge (:kw split#) (:options parsed#))
                    ~'*args*  args#
                    ~'*usage* #(print ~cli-doc)]
-               (when-let [e# (seq (:errors parsed#))]
+               (when-let [e# (seq (mapcat :errors [split# parsed#]))]
                  (throw (IllegalArgumentException. (string/join "\n" e#))))
                ~@(mapv (partial apply argspec->assert) argspecs)
                ~@(mapv (partial apply argspec->deprecation-warning) argspecs)

--- a/boot/core/src/boot/cli.clj
+++ b/boot/core/src/boot/cli.clj
@@ -163,12 +163,11 @@
     (:summary (cli/parse-opts [] cli-args))))
 
 (defn- split-args [args]
-  (loop [kw {} cli [] [arg & more] args]
-    (if-not arg
-      {:kw kw :cli cli}
-      (if-not (keyword? arg)
-        (recur kw (conj cli arg) more)
-        (recur (assoc kw arg (first more)) cli (rest more))))))
+  (loop [split {} [arg & more] args]
+    (cond
+      (nil? arg) split
+      (not (keyword? arg)) (recur (update-in split [:cli] (fnil conj []) arg) more)
+      :else (recur (update-in split [:kw] assoc arg (first more)) (rest more)))))
 
 (defmacro ^:private assert
   [test fmt & args]

--- a/boot/core/src/boot/cli.clj
+++ b/boot/core/src/boot/cli.clj
@@ -169,7 +169,7 @@
       (not (keyword? arg)) (recur (update-in split [:cli] (fnil conj []) arg) more)
       (empty? more) (update-in split [:errors] (fnil conj [])
                                (str "no value supplied for option " arg))
-      :else (recur (update-in split [:kw] assoc arg (first more)) (rest more)))))
+      :else (recur (assoc-in split [:kw arg] (first more)) (rest more)))))
 
 (defmacro ^:private assert
   [test fmt & args]


### PR DESCRIPTION
I'm just starting to learn Boot, and I spent a few hours scratching my head when `(aot :all)` or `(show :fileset)` gave different results from `(aot "-a")` or `(show "-f")`. This patch throws an exception if the last keyword argument to a task is not supplied a value.