### PR TITLE
Fix deftask overriden warning in deftesttask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
 
 install: make deps
 script: make test

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -19,8 +19,7 @@
    [boot.from.digest     :as digest]
    [boot.task-helpers    :as helpers]
    [boot.task-helpers.notify :as notify]
-   [boot.pedantic        :as pedantic]
-   [boot.test            :as test])
+   [boot.pedantic        :as pedantic])
   (:import
    [java.io File]
    [java.util Arrays]

--- a/boot/core/src/boot/test.clj
+++ b/boot/core/src/boot/test.clj
@@ -108,7 +108,6 @@
   deftask or comp. Another way to say it is that a boot middleware
   should be passed here."
   [task]
-  ;; TODO - deftesttask
   (pod/add-shutdown-hook! #(done! pod/data))
   (.await (get pod/data "start-latch"))
   (try
@@ -154,12 +153,12 @@
       (testing \"whatever\"
         (is true \"Whatever must be true\"))))
 
-  When *load-tests* is false, deftesttask is ignored."
+  When clojure.test/*load-tests* is false, deftesttask is ignored."
   [& forms]
   (when test/*load-tests*
     (let [new-forms (-> forms
                         (boot.test/update-body #(cons 'boot.test/test-task (list %))))]
-      `(alter-meta! (core/deftask ~@new-forms) assoc ::test-task ::test-me))))
+      `(do (core/deftask ~@new-forms) (alter-meta! (var ~(first new-forms)) assoc ::test-task ::test-me)))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;  Test Vars   ;;


### PR DESCRIPTION
After a tireless Sunday, I (we, thanks @micha) realized that alter-meta! in `deftesttask` needs to be applied after the def takes place. This was triggering the dreaded "deftask ... was overridden".