### PR TITLE
Add mkdirs to Makefile in order to generate bin folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,17 @@ clean:
 	(cd boot/aether && lein clean)
 	(cd boot/pod && lein clean)
 	(cd boot/worker && lein clean)
+	(rm -Rfv bin)
 	(rm -fv .installed .deployed .tested)
 
-bin/lein:
+mkdirs:
 	mkdir -p bin
+
+bin/lein: mkdirs
 	wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O bin/lein
 	chmod 755 bin/lein
 
-bin/boot:
+bin/boot: mkdirs
 	curl -fsSLo bin/boot https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
 	chmod 755 bin/boot
 
@@ -67,7 +70,7 @@ $(corejar): $(verfile) boot/core/project.clj $(shell find boot/core/src)
 $(baseuber): boot/base/pom.xml $(shell find boot/base/src/main)
 	(cd boot/base && mvn -q assembly:assembly -DdescriptorId=jar-with-dependencies)
 
-.installed: $(basejar) $(alljars)
+.installed: mkdirs $(basejar) $(alljars)
 	cp $(baseuber) $(distjar)
 	# FIXME: this is just for testing -- remove before release
 	mkdir -p $$HOME/.boot/cache/bin/$(version)


### PR DESCRIPTION
This slightly corrects the Makefile. I found a problem when cloning and building master and had to generate `bin` as separate step inside the `.installed` step.