### PR TITLE
Fix boot.test/runtests, ns-interns is evaluated at task execution

### DIFF
--- a/boot/core/build.boot
+++ b/boot/core/build.boot
@@ -2,7 +2,7 @@
  :source-paths #{"test"}
  :dependencies '[[org.clojure/tools.reader "1.0.0-alpha2"]])
 
-(require '[boot.test :as test :refer [runtests test-report test-exit]]
+(require '[boot.test :refer [runtests test-report test-exit]]
          'boot.task.built-in-test
          'boot.test-test)
 
@@ -12,6 +12,6 @@
 
 (deftask test []
   (boot.util/info "Testing against version %s\n" (App/config "BOOT_VERSION"))
-  (comp (test/runtests)
-        (test/test-report)
-        (test/test-exit)))
+  (comp (runtests)
+        (test-report)
+        (test-exit)))

--- a/boot/core/src/boot/parallel.clj
+++ b/boot/core/src/boot/parallel.clj
@@ -122,7 +122,7 @@ The first item of the vector is timeout, the second unit"}
   (string/split command-str #"\s"))
 
 (defn task-sync-map
-  "Add batch-specific keys to the input sync map.
+  "Add task-specific keys to the input sync map.
 
   This function currently clones, adds keys and returns a HashMap whose
   values will be modified during the parallel computation. Make sure
@@ -206,7 +206,7 @@ The first item of the vector is timeout, the second unit"}
         sync-map (parallel-init-fn (empty-sync-map))
         seqs-of-cmds (partition-all n commands)
         seqs-of-midwares (map #(commands->parallel-task sync-map %) seqs-of-cmds)]
-    (util/dbug "Middleware command partitions: %s.\n" (vec seqs-of-cmds))
+    (util/dbug "Partitions: %s.\n" (vec seqs-of-cmds))
     (core/with-pre-wrap [fileset]
       (reduce (fn [prev-fs mw]
                 (let [handler (mw identity)] ;; this triggers the parallel computation


### PR DESCRIPTION
In order for the autodiscovery of deftesttask to work, an ns-interns call is necessary. The problem
was that before this patch boot.test/runtest was executing it at task creation time, necessitating a
require in build.boot for it to work.

Potentially though, the require of the test can be done in a separate task right before calling
boot.test/runtest.

This is why ns-interns has been moved at task execution time (inside a with-pass-thru, storing in an
atom the detected commands).