### PR TITLE
Fix memory leak in pods

### DIFF
--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -276,6 +276,11 @@
   boot. See #'boot.pod/add-shutdown-hook! for more info."
   (atom nil))
 
+(def ^:dynamic *destroy-pod-hook*
+  "Bind this to a 0-arity function in order to perform additional
+  cleanup."
+  identity)
+
 (defn set-pods!         [x] (alter-var-root #'pods        (constantly x)))
 (defn set-data!         [x] (alter-var-root #'data        (constantly x)))
 (defn set-pod-id!       [x] (alter-var-root #'pod-id      (constantly x)))
@@ -823,6 +828,7 @@
   "Closes open resources held by the pod, making the pod eligible for GC."
   [pod]
   (when pod
+    (*destroy-pod-hook*)
     (.close pod)
     (.. pod getClassLoader close)))
 


### PR DESCRIPTION
This was particularly evident when doing `boot watch test` and has been fixed thanks to Micha's
intuition of adding a clojure.core/shutdown-agents in boot.pod/destroy-pod.

Fixes https://github.com/adzerk-oss/boot-test/issues/26
