### PR TITLE
Do not force Vicki’s voice for notifications

### DIFF
--- a/boot/worker/src/boot/notify.clj
+++ b/boot/worker/src/boot/notify.clj
@@ -36,7 +36,7 @@
           (.exists (File. "/usr/bin/espeak"))
           (sh "espeak" "-v+f2" msg)
           (.exists (File. "/usr/bin/say"))
-          (sh "say" "-v" "Vicki" msg)
+          (sh "say" msg)
           :else (play! (or file (path-for theme "warning"))))))))
 
 (defn notify! [{:keys [file theme type]}]


### PR DESCRIPTION
Vicki was a nice voice a while back, but now that Apple finally supplied us with wide variety of high quality voices, it seems such a waste to torture us with Vicki's robotic pronunciation.

By using systems default voice user themselves can decide which voice he likes best.

Or maybe we can have a setting for this somewhere, which seems to be an overkill for such simple task.