### PR TITLE
flatten only top level to avoid breaking values that are collections

### DIFF
--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -340,7 +340,7 @@
   [{:keys [project version] :as dep-map}]
   (let [kvs (remove #(or (some #{:project :version} %)
                          (= [:scope "compile"] %)) dep-map)]
-    (vec (remove nil? (into [project version] (flatten kvs))))))
+    (vec (remove nil? (into [project version] (mapcat identity kvs))))))
 
 (defn jarname
   "Generates a friendly name for the jar file associated with the given project


### PR DESCRIPTION
The function `map-as-dep` flattens values that are collections (like :exclusions), creating an invalid specification. The following shows this behavior:

```clojure
(set-env!
 :dependencies '[[org.clojure/clojure "1.8.0"]])

(require '[clojure.test :refer [is]])

(def dep-map {:project 'myproject
              :version "1.0.0"
              :exclusions '[excl1 excl2]})

(def dep '[myproject "1.0.0" :exclusions [excl1 excl2]])

(is (= dep (boot.util/map-as-dep dep-map)))
```
which results in the output:
```
FAIL in () (boot.user4426527561266792223.clj:23)
expected: (= dep (boot.util/map-as-dep dep-map))
  actual: (not (= [myproject "1.0.0" :exclusions [excl1 excl2]] [myproject "1.0.0" :exclusions excl1 excl2]))
```
This PR flattens only the top-level, preserving the values that are collections.

Let me know if there's a place to add unit tests.  If so, I can add a test of this behavior.
