### PR TITLE
Fix path format for `fake.class.path` on Windows

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -21,7 +21,7 @@
   (:import
     [boot App]
     [java.io File]
-    [java.nio.file Path]
+    [java.nio.file Path Paths]
     [java.net URLClassLoader URL]
     [java.lang.management ManagementFactory]
     [java.util.concurrent LinkedBlockingQueue TimeUnit Semaphore ExecutionException]))
@@ -165,7 +165,8 @@
                                    ((juxt :source-paths :resource-paths))
                                    (apply concat)
                                    (map #(.getAbsolutePath (io/file %))))
-              paths           (->> (pod/get-classpath) (map #(.getPath (URL. %))))
+              paths           (->> (pod/get-classpath)
+                                   (map #(.getPath (.toFile (Paths/get (.toURI (URL. %)))))))
               dir?            (comp (memfn isDirectory) io/file)
               fake-paths      (->> paths (remove dir?) (concat user-dirs))
               separated       (partial string/join (System/getProperty "path.separator"))


### PR DESCRIPTION
The `fake.class.path` env variable is currently populated in a way that
leaves an extraneous leading forward slash character at the start of all
path components on Windows, so that:

  "C:\\Program Files\\Java\\jdk1.8.0_77\\jre\\lib\\ext\\access-bridge-64.jar"

Ends up being represented as:

  "/C:/Program Files/Java/jdk1.8.0_77/jre/lib/ext/access-bridge-64.jar"

This patch uses `java.nio.file.Paths` to properly convert each component
of the classpath to a valid system-specific path before using it to
populate the `fake.class.path` variable.