### PR TITLE
extend dep. mgt. functions; add unit tests

### DIFF
--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -327,20 +327,22 @@
 
 (defn dep-as-map
   "Returns the given dependency vector as a map with :project and :version
-  keys plus any modifiers (eg. :scope, :exclusions, etc)."
-  [[project version & kvs]]
-  (let [d {:project project :version version}]
-    (merge {:scope "compile"}
-      (if-not (seq kvs) d (apply assoc d kvs)))))
+  keys plus any modifiers (eg. :scope, :exclusions, etc).  If the version
+  is not specified, nil will be used."
+  [[project & terms]]
+  (let [[version & kvs] (if (odd? (count terms)) terms (cons nil terms))
+        d {:project project :version version :scope "compile"}]
+    (if-not (seq kvs) d (apply assoc d kvs))))
 
 (defn map-as-dep
   "Returns the given dependency vector with :project and :version put at
-  index 0 and 1 respectively and modifiers (eg. :scope, :exclusions,
-  etc) next."
+  indexes 0 and 1 respectively (if the values are not nil) and modifiers
+  (e.g. :scope, :exclusions, etc.) and their values afterwards."
   [{:keys [project version] :as dep-map}]
   (let [kvs (remove #(or (some #{:project :version} %)
-                         (= [:scope "compile"] %)) dep-map)]
-    (vec (remove nil? (into [project version] (mapcat identity kvs))))))
+                         (= [:scope "compile"] %)) dep-map)
+        d (vec (remove nil? [project version]))]
+    (vec (into d (mapcat identity kvs)))))
 
 (defn jarname
   "Generates a friendly name for the jar file associated with the given project

--- a/boot/pod/test/boot/util_test.clj
+++ b/boot/pod/test/boot/util_test.clj
@@ -1,0 +1,137 @@
+(ns boot.util-test
+  (:require
+   [clojure.test :refer :all]
+   [boot.util :as util :refer :all]))
+
+(deftest dep-mgt-functions
+  
+  (let [project 'com.example/project
+        version "1.2.3"
+        scope "test"
+        exclusions [['com.example/excl1 :extension "jar"]
+                    'com.example/excl2]]
+    
+    (testing "simple dep-as-map conversions"
+      (are [input expected] (= expected (dep-as-map input))
+
+           nil
+           {:project nil
+            :version nil
+            :scope "compile"}
+
+           []
+           {:project nil
+            :version nil
+            :scope "compile"}
+           
+           [project]
+           {:project project
+            :version nil
+            :scope "compile"}
+           
+           [project version]
+           {:project project
+            :version version
+            :scope "compile"}
+           
+           [project version :scope scope]
+           {:project project
+            :version version
+            :scope scope}
+           
+           [project version :scope scope :exclusions exclusions]
+           {:project project
+            :version version
+            :scope scope
+            :exclusions exclusions}
+
+           ;; checks that options with nil values are retained
+           [project version :scope scope :exclusions exclusions :other nil]
+           {:project project
+            :version version
+            :scope scope
+            :exclusions exclusions
+            :other nil}
+
+           ;; checks that optional version with option works
+           [project :scope scope]
+           {:project project
+            :version nil
+            :scope scope}))
+    
+    (testing "simple map-as-dep conversions"      
+      (are [input expected] (= expected (map-as-dep input))
+
+           {}
+           []
+           
+           {:project project
+            :version nil
+            :scope "compile"}
+           [project]
+           
+           {:project project
+            :version version
+            :scope "compile"}
+           [project version]
+           
+           {:project project
+            :version version
+            :scope scope}
+           [project version :scope scope]
+           
+           {:project project
+            :version version
+            :exclusions exclusions}
+           [project version :exclusions exclusions]
+
+           ;; checks that options with nil values are retained
+           {:project project
+            :version version
+            :other nil}
+           [project version :other nil]
+
+           ;; checks that optional version with option works
+           {:project project
+            :version nil
+            :scope scope}
+           [project :scope scope]))
+
+    (testing "roundtripping deps"
+      
+      (are [input] (= input (dep-as-map (map-as-dep input)))
+           
+           {:project project
+            :version nil
+            :scope "compile"}
+           
+           {:project project
+            :version version
+            :scope "compile"}
+           
+           {:project project
+            :version version
+            :scope scope}
+           
+           {:project project
+            :version version
+            :scope scope
+            :exclusions exclusions}
+
+           ;; checks that options with nil values are retained
+           {:project project
+            :version version
+            :scope scope
+            :exclusions exclusions
+            :other nil}
+
+           ;; checks that optional version with option works
+           {:project project
+            :version nil
+            :scope scope}))
+
+    (testing "check unusual arguments"
+      (is (thrown? Exception (dep-as-map {})))
+      (is (= [] (map-as-dep nil)))
+      (is (= [] (map-as-dep [])))
+      (is (thrown? Exception (map-as-dep 3))))))


### PR DESCRIPTION
Provides unit tests of the `dep-as-map` and `map-as-dep` utility functions.  Verifies that the fix in the accepted PR #479 works correctly.

In addition, this PR extends these functions to treat dependency vectors that do not have a version specified, such as:
```
['example/project]
['example/project :scope "test"]
```
Such incomplete specifications are useful when handling dependency versions and options centrally. At SixSq, we use a function to pull in a central list of dependency specifications to complete any dependencies in the local `build.boot` file.

The change also will allow options with nil values to be retained.  This may not be useful, but it eliminates a case where one function could produce a value that wasn't accepted by the other.  Previously,
```
(map-as-dep {:project 'example/project :version "1.0.0" :option nil})
;; produced
;; ['example/project "1.0.0" :option]
```
which wasn't valid.  It now produces:
```
['example/project "1.0.0" :option nil]
```
