### PR TITLE
implement managed dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ pom.xml.asc
 /zzz/
 /launch4j-config.xml
 /launch4j/
+
+### INTELLIJ ###################################################################
+
+.idea
+*.iml
+

--- a/boot/aether/project.clj
+++ b/boot/aether/project.clj
@@ -16,5 +16,5 @@
   :dependencies [[org.clojure/clojure               "1.6.0"  :scope "compile"]
                  [boot/base                         ~version :scope "provided"]
                  [boot/pod                          ~version :scope "compile"]
-                 [com.cemerick/pomegranate          "0.3.0"  :scope "compile"]
+                 [com.cemerick/pomegranate          "0.3.1"  :scope "compile"]
                  [org.apache.maven.wagon/wagon-http "2.9"    :scope "compile"]])

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -5,6 +5,7 @@
     [clojure.pprint              :as pprint]
     [cemerick.pomegranate.aether :as aether]
     [boot.util                   :as util]
+    [boot.deps-util              :as deps-util]
     [boot.pod                    :as pod]
     [boot.gpg                    :as gpg]
     [boot.from.io.aviso.ansi     :as ansi]
@@ -104,7 +105,7 @@
   [env]
   (try
     (aether/resolve-dependencies
-      :coordinates       (:dependencies env)
+      :coordinates       (deps-util/merge-deps (:dependencies env) (:managed-dependencies env))
       :repositories      (->> (or (seq (:repositories env)) @default-repositories)
                            (map (juxt first (fn [[x y]] (if (map? y) y {:url y}))))
                            (map (juxt first (fn [[x y]] (update-in y [:update] #(or % @update?))))))

--- a/boot/core/project.clj
+++ b/boot/core/project.clj
@@ -16,4 +16,3 @@
   :dependencies   [[org.clojure/clojure "1.6.0"  :scope "provided"]
                    [boot/base           ~version :scope "provided"]
                    [boot/pod            ~version :scope "compile"]])
-

--- a/boot/core/src/boot/deps.clj
+++ b/boot/core/src/boot/deps.clj
@@ -1,0 +1,26 @@
+(ns boot.deps
+  (:refer-clojure :exclude [load])
+  (:require
+    [boot.core :as boot]
+    [boot.pod :as pod]))
+
+(defn load
+  "Loads dependency specifications from a resource inside the given
+   dependency or on the given path.  Keyword options can be provided
+   after the dep-or-path.  The supported options are:
+     :resource The resource name to use to read in the dependencies.
+               If the resource is not provided, then the default
+               \"dependencies.edn\" will be used.
+     :xfn      A function used to transform the loaded dependencies.
+               Takes a list of dependencies and returns a list of
+               transformed dependencies.  Defaults to the identity
+               function."
+  [dep-or-path & {:keys [resource xfn]
+                  :or   {xfn identity}}]
+  (let [path (when (string? dep-or-path) dep-or-path)
+        dep (if (vector? dep-or-path) [dep-or-path] [])]
+    (-> (boot/get-env)
+        (assoc :dependencies dep)
+        pod/make-pod
+        (pod/with-call-in (boot.deps-util/read-deps ~path ~resource))
+        xfn)))

--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -18,4 +18,5 @@
   :dependencies   [[boot/base                               ~version :scope "provided"]
                    [org.clojure/clojure                     "1.6.0"  :scope "provided"]
                    [org.tcrawley/dynapath                   "0.2.3"  :scope "compile"]
-                   [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]])
+                   [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]]
+  :profiles {:dev {:resource-paths ["test-resources"]}})

--- a/boot/pod/src/boot/deps_util.clj
+++ b/boot/pod/src/boot/deps_util.clj
@@ -1,0 +1,71 @@
+(ns boot.deps-util
+  (:require
+    [clojure.java.io :as io]
+    [clojure.edn :as edn]
+    [boot.pod :as pod]
+    [boot.util :as util]))
+
+(defn- maybe-strip-scope
+  "Strip the generated scope field unless it was explicitly defined."
+  [dep dep-map]
+  (if (some #{:scope} dep)
+    dep-map
+    (dissoc dep-map :scope)))
+
+(defn- dep-key
+  [{:keys [project extension classifier]
+    :or   {extension "jar"}}]
+  (if classifier
+    [project extension classifier]
+    [project extension]))
+
+(defn- managed-deps-map
+  "Accepts a list of dependency specifications and returns a
+   map where the values are the map representation of the dependency
+   and the key is the value of :project in the dependency."
+  [managed-deps]
+  (->> managed-deps
+       (map util/dep-as-map)
+       (remove nil?)
+       (map (juxt dep-key identity))
+       (into {})))
+
+(defn- complete-dep
+  "Completes the information in the given dependency with the information
+   from the managed dependency map."
+  [managed-deps-map dep]
+  (let [dep-map (util/dep-as-map dep)
+        k (dep-key dep-map)]
+    (if-let [managed-dep-map (get managed-deps-map k)]
+      (->> dep-map
+           (maybe-strip-scope dep)
+           (filter second)
+           (into {})
+           (merge managed-dep-map)
+           util/map-as-dep)
+      dep)))
+
+(defn- complete-deps
+  "Iterates over the list of dependencies, completing values
+   from the defaults for each dependency."
+  [managed-deps-map deps]
+  (vec (map (partial complete-dep managed-deps-map) deps)))
+
+(defn merge-deps [deps managed-deps]
+  (complete-deps (managed-deps-map managed-deps) deps))
+
+(defn read-deps
+  "Reads dependencies from the resource with the given resource-name. If
+   dir is not nil, that directory will be added to the classpath. It should
+   be a file or string. If the resource name is not provided it defaults
+   to \"dependencies.edn\". If the resource is not found on the classpath,
+   then nil is returned. Exceptions will be thrown if there are reading or
+   parsing errors.  Note: this function modifies the classpath if \"dir\"
+   is provided."
+  [dir resource-name]
+  (when dir (pod/add-classpath dir))
+  (some-> (or resource-name "dependencies.edn")
+          io/resource
+          slurp
+          edn/read-string))
+

--- a/boot/pod/test-resources/bad-dependencies.edn
+++ b/boot/pod/test-resources/bad-dependencies.edn
@@ -1,0 +1,1 @@
+} invalid-syntax {

--- a/boot/pod/test-resources/dependencies.edn
+++ b/boot/pod/test-resources/dependencies.edn
@@ -1,0 +1,2 @@
+[[example/project1 "1.0.0" :scope "test"]
+ [example/project2 "2.0.0" :scope "compile"]]

--- a/boot/pod/test-resources/managed-dependencies.edn
+++ b/boot/pod/test-resources/managed-dependencies.edn
@@ -1,0 +1,2 @@
+[[example/project3 "3.0.0" :scope "test"]
+ [example/project4 "4.0.0" :scope "compile"]]

--- a/boot/pod/test/boot/deps_util_test.clj
+++ b/boot/pod/test/boot/deps_util_test.clj
@@ -1,0 +1,165 @@
+(ns boot.deps-util-test
+  (:require
+    [clojure.test :refer :all]
+    [boot.deps-util :refer :all]
+    [boot.util :as util]))
+
+(def ^:const test-deps '[[alpha/beta "1.0.0"]
+                         [gamma/delta "2.0.0" :a "a" :scope "test"]
+                         [test/excl "1.2.3" :exclusions [a b c d]]
+                         [foo/foo "4.5.6" :scope "test"]
+                         [bar/bar "7.8.9" :extension "zip"]
+                         [test/cls "7.8.9" :extension "zip" :classifier "other"]])
+
+(def ^:const test-indexed-map {['alpha/beta "jar"]       {:project   'alpha/beta
+                                                          :version   "1.0.0"
+                                                          :extension "jar"
+                                                          :scope     "compile"}
+                               ['gamma/delta "jar"]      {:project   'gamma/delta
+                                                          :version   "2.0.0"
+                                                          :extension "jar"
+                                                          :scope     "test"
+                                                          :a         "a"}
+                               ['test/excl "jar"]        {:project    'test/excl
+                                                          :version    "1.2.3"
+                                                          :extension  "jar"
+                                                          :scope      "compile"
+                                                          :exclusions '[a b c d]}
+                               ['foo "jar"]              {:project   'foo
+                                                          :version   "4.5.6"
+                                                          :extension "jar"
+                                                          :scope     "test"}
+                               ['bar "zip"]              {:project   'bar
+                                                          :version   "7.8.9"
+                                                          :extension "zip"
+                                                          :scope     "compile"}
+                               ['test/cls "zip" "other"] {:project    'test/cls
+                                                          :version    "7.8.9"
+                                                          :extension  "zip"
+                                                          :classifier "other"
+                                                          :scope      "compile"}})
+
+(deftest check-maybe-strip-scope
+  (let [maybe-strip-scope @#'boot.deps-util/maybe-strip-scope]
+    (are [scope? dep] (= scope? (->> dep
+                                     util/dep-as-map
+                                     (maybe-strip-scope dep)
+                                     :scope
+                                     boolean))
+                      true '[alpha/beta "1.0.0" :scope "test"]
+                      false '[alpha/beta "1.0.0"])))
+
+(deftest check-dep-key
+  (let [dep-key @#'boot.deps-util/dep-key]
+    (are [input key] (= key (dep-key input))
+
+                     {}
+                     [nil "jar"]
+
+                     {:project 'foo}
+                     ['foo "jar"]
+
+                     {:project   'foo
+                      :extension "zip"}
+                     ['foo "zip"]
+
+                     {:project    'foo
+                      :extension  "jar"
+                      :classifier "other"}
+                     ['foo "jar" "other"])))
+
+(deftest check-managed-deps-map
+  (let [managed-deps-map @#'boot.deps-util/managed-deps-map]
+    (is (= {} (managed-deps-map nil)))
+    (is (= test-indexed-map (managed-deps-map test-deps)))))
+
+(deftest check-complete-dep
+  (let [complete-dep @#'boot.deps-util/complete-dep
+        managed-deps-map @#'boot.deps-util/managed-deps-map
+        managed-deps (managed-deps-map test-deps)
+        f (partial complete-dep managed-deps)]
+    ;; must compare maps because option order is not stable in vectors
+    (are [x y] (= (util/dep-as-map x) (util/dep-as-map (f y)))
+               '[alpha/beta "1.0.0"] '[alpha/beta]
+               '[alpha/beta "1.0.0" :b "b"] '[alpha/beta nil :b "b"]
+               '[gamma/delta "2.0.0" :scope "test" :a "a"] '[gamma/delta]
+               '[test/excl "1.2.3" :exclusions [a b c d]] '[test/excl])))
+
+(deftest check-complete-deps
+  (let [managed-deps-map @#'boot.deps-util/managed-deps-map
+        complete-deps @#'boot.deps-util/complete-deps
+        managed-deps (managed-deps-map test-deps)]
+    (is (= [] (complete-deps managed-deps nil)))
+    (is (= [] (complete-deps nil nil)))
+
+    ;; must compare maps because option order is not stable in vectors
+    (are [x y] (= (map util/dep-as-map x) (map util/dep-as-map (complete-deps managed-deps y)))
+               '[[alpha/beta "1.0.0" :b "b"]
+                 [gamma/delta "2.0.0" :scope "test" :a "a"]]
+               '[[alpha/beta nil :b "b"]
+                 [gamma/delta]]
+
+               '[[gamma/delta "2.0.0" :scope "test" :a "a"]
+                 [alpha/beta "1.0.0" :b "b"]]
+               '[[gamma/delta]
+                 [alpha/beta nil :b "b"]]
+
+               '[[gamma/delta "2.0.0" :a "a"]
+                 [alpha/beta "1.0.0" :b "b"]]
+               '[[gamma/delta nil :scope "compile"]
+                 [alpha/beta nil :b "b"]]
+
+               '[[gamma/delta "2.0.0" :scope "test" :a "a"]
+                 [alpha/beta "1.0.0" :b "b"]
+                 [alpha/omega]]
+               '[[gamma/delta]
+                 [alpha/beta nil :b "b"]
+                 [alpha/omega]]
+
+               '[[alpha/omega]
+                 [test/excl "1.2.3" :exclusions [a b c d]]]
+               '[[alpha/omega]
+                 [test/excl]])))
+
+(deftest check-merge-deps
+  (is (= [] (merge-deps nil test-deps)))
+  (is (= [] (merge-deps nil nil)))
+
+  ;; must compare maps because option order is not stable in vectors
+  (are [x y] (= (map util/dep-as-map x) (map util/dep-as-map (merge-deps y test-deps)))
+             '[[alpha/beta "1.0.0" :b "b"]
+               [gamma/delta "2.0.0" :scope "test" :a "a"]]
+             '[[alpha/beta nil :b "b"]
+               [gamma/delta]]
+
+             '[[gamma/delta "2.0.0" :scope "test" :a "a"]
+               [alpha/beta "1.0.0" :b "b"]]
+             '[[gamma/delta]
+               [alpha/beta nil :b "b"]]
+
+             '[[gamma/delta "2.0.0" :a "a"]
+               [alpha/beta "1.0.0" :b "b"]]
+             '[[gamma/delta nil :scope "compile"]
+               [alpha/beta nil :b "b"]]
+
+             '[[gamma/delta "2.0.0" :scope "test" :a "a"]
+               [alpha/beta "1.0.0" :b "b"]
+               [alpha/omega]]
+             '[[gamma/delta]
+               [alpha/beta nil :b "b"]
+               [alpha/omega]]
+
+             '[[alpha/omega]
+               [test/excl "1.2.3" :exclusions [a b c d]]]
+             '[[alpha/omega]
+               [test/excl]]))
+
+(deftest check-read-deps
+  (is (= [['example/project1 "1.0.0" :scope "test"]
+          ['example/project2 "2.0.0" :scope "compile"]]
+         (read-deps nil nil)))
+  (is (= [['example/project3 "3.0.0" :scope "test"]
+          ['example/project4 "4.0.0" :scope "compile"]]
+         (read-deps nil "managed-dependencies.edn")))
+  (is (nil? (read-deps nil "unknown-file.edn")))
+  (is (thrown? Exception (read-deps nil "bad-dependencies.edn"))))

--- a/boot/pod/test/boot/util_test.clj
+++ b/boot/pod/test/boot/util_test.clj
@@ -3,45 +3,88 @@
    [clojure.test :refer :all]
    [boot.util :as util :refer :all]))
 
+(deftest check-canonical-id
+  (is (nil? (canonical-id nil)))
+  (is (nil? (canonical-id "BAD")))
+  (is (nil? (canonical-id 0xBAD)))
+  (is (= 'foo (canonical-id 'foo/foo)))
+  (is (= 'foo/bar (canonical-id 'foo/bar))))
+
+(deftest check-full-id
+  (is (nil? (full-id nil)))
+  (is (nil? (full-id "BAD")))
+  (is (nil? (full-id 0xBAD)))
+  (is (= 'foo/foo (full-id 'foo)))
+  (is (= 'foo/bar (full-id 'foo/bar))))
+
+(deftest check-canonical-coord
+  (is (nil? (canonical-coord nil)))
+  (is (nil? (canonical-coord [])))
+  (is (thrown? Exception (canonical-coord 0xBAD)))
+  (is (= '[foo "1.2.3" :scope "test"] (canonical-coord '[foo/foo "1.2.3" :scope "test"])))
+  (is (= '[foo/bar "1.2.3" :scope "test"] (canonical-coord '[foo/bar "1.2.3" :scope "test"]))))
+
 (deftest dep-mgt-functions
-  
+
   (let [project 'com.example/project
+        noncanonical-project 'foo/foo
+        canonical-project 'foo
         version "1.2.3"
         scope "test"
+        type "zip"
         exclusions [['com.example/excl1 :extension "jar"]
                     'com.example/excl2]]
-    
+
     (testing "simple dep-as-map conversions"
       (are [input expected] (= expected (dep-as-map input))
 
            nil
            {:project nil
             :version nil
+            :extension "jar"
             :scope "compile"}
 
            []
            {:project nil
             :version nil
+            :extension "jar"
             :scope "compile"}
-           
+
            [project]
            {:project project
             :version nil
+            :extension "jar"
             :scope "compile"}
-           
+
            [project version]
            {:project project
             :version version
+            :extension "jar"
             :scope "compile"}
-           
+
            [project version :scope scope]
            {:project project
             :version version
+            :extension "jar"
             :scope scope}
-           
+
+           [project version :extension type]
+           {:project project
+            :version version
+            :extension type
+            :scope "compile"}
+
            [project version :scope scope :exclusions exclusions]
            {:project project
             :version version
+            :extension "jar"
+            :scope scope
+            :exclusions exclusions}
+
+           [project version :scope scope :extension type :exclusions exclusions]
+           {:project project
+            :version version
+            :extension type
             :scope scope
             :exclusions exclusions}
 
@@ -49,6 +92,7 @@
            [project version :scope scope :exclusions exclusions :other nil]
            {:project project
             :version version
+            :extension "jar"
             :scope scope
             :exclusions exclusions
             :other nil}
@@ -57,29 +101,43 @@
            [project :scope scope]
            {:project project
             :version nil
+            :extension "jar"
+            :scope scope}
+
+           ;; check that canonical project id is always used
+           [noncanonical-project version :scope scope]
+           {:project canonical-project
+            :version version
+            :extension "jar"
             :scope scope}))
-    
-    (testing "simple map-as-dep conversions"      
+
+    (testing "simple map-as-dep conversions"
       (are [input expected] (= expected (map-as-dep input))
 
            {}
            []
-           
+
            {:project project
             :version nil
             :scope "compile"}
            [project]
-           
+
            {:project project
             :version version
             :scope "compile"}
            [project version]
-           
+
            {:project project
             :version version
             :scope scope}
            [project version :scope scope]
-           
+
+           {:project project
+            :version version
+            :extension type
+            :scope "compile"}
+           [project version :extension type]
+
            {:project project
             :version version
             :exclusions exclusions}
@@ -95,32 +153,55 @@
            {:project project
             :version nil
             :scope scope}
-           [project :scope scope]))
+           [project :scope scope]
 
-    (testing "roundtripping deps"
-      
-      (are [input] (= input (dep-as-map (map-as-dep input)))
-           
-           {:project project
-            :version nil
-            :scope "compile"}
-           
-           {:project project
-            :version version
-            :scope "compile"}
-           
-           {:project project
+           ;; checks that canonical project id is always used
+           {:project noncanonical-project
             :version version
             :scope scope}
-           
+           [canonical-project version :scope scope]))
+
+    (testing "roundtripping deps"
+
+      (are [input] (= input (dep-as-map (map-as-dep input)))
+
+           {:project project
+            :version nil
+            :extension "jar"
+            :scope "compile"}
+
            {:project project
             :version version
+            :extension "jar"
+            :scope "compile"}
+
+           {:project project
+            :version version
+            :extension "jar"
+            :scope scope}
+
+
+           {:project project
+            :version version
+            :extension type
+            :scope "compile"}
+
+           {:project project
+            :version version
+            :extension type
+            :scope scope
+            :exclusions exclusions}
+
+           {:project project
+            :version version
+            :extension type
             :scope scope
             :exclusions exclusions}
 
            ;; checks that options with nil values are retained
            {:project project
             :version version
+            :extension type
             :scope scope
             :exclusions exclusions
             :other nil}
@@ -128,6 +209,7 @@
            ;; checks that optional version with option works
            {:project project
             :version nil
+            :extension type
             :scope scope}))
 
     (testing "check unusual arguments"


### PR DESCRIPTION
This PR allows the use of "managed dependencies" when defining the dependencies for a project.  This is a useful feature when trying to maintain consistent dependency versions, scopes, exclusions, etc. between a number of different projects.

Although most people maintain the dependency list directly within the `build.boot` file itself, this PR will also allow dependencies to be read in from an external file, either in the project hierarchy or from a maven artifact. The typical usage in this case is:

```
(require '[boot.deps :as deps])

(set-env!
  :dependencies
    (deps/load "deps"))
```
This will load the `dependencies.edn` file from the `deps` subdirectory within the project.  The `deps` subdirectory and the `dependencies.edn` file will not be added to the project's fileset. 

This will probably be more often used to read in a list of managed dependencies.  In this case, the usage would be:

```
(require '[boot.deps :as deps])

(set-env!
  :managed-dependencies
    (deps/load 
      '[example/deps "1.0.0"]
      :resource "managed-dependencies.edn")
  :dependencies 
    '[[foo/bar]
      [baz]])
```
Here, the name of the resource has been changed and the file with the dependencies is instead loaded from the defined artifact.  Again, the dependency file and the artifact are not added to the project.  In this case, the versions and perhaps other options will be merged into the (incomplete) dependencies listed in `:dependencies`. 

It is also possible to transform the loaded dependencies before passing them on to `boot`.  For example,

```
(require 
   '[boot.deps :as deps]
   '[clojure.walk :as walk])

(set-env!
  :managed-dependencies 
    (deps/load 
      '[example/deps "1.0.0"]
      :resource "managed-dependencies.edn"
      :xfn #(walk/postwalk-replace {:version "1.2.3"} %))
  :dependencies
    '[[foo/bar]
      [baz]])
```
In this case, any`:version` keywords will be replaced by "1.2.3".  This is often useful for cross-project dependencies where the projects share a common version number.  Rather than a hard-coded value, this would probably be taken from the project version definition. 

Some comments about the implementation:

 * This includes an update to pomegranate v0.3.1.  This version implements managed dependencies. Unfortunately, it also allows versions to be managed (not other characteristics, especially exclusions). It also doesn't appear to allow jar and non-jar dependencies to be managed separately.  These are the reasons why this PR implements the managed dependencies itself, rather than relying on the pomegranate implementation. 

 * It updates the `.gitignore` file to exclude files from IntelliJ.  This could be removed from the PR if it isn't desired, but this seems to be a harmless addition (and is useful for me).

 * I've updated the `map-as-dep` and `dep-as-map` functions to also treat correctly the "extension" value for the dependency. 

 * There were a number of duplicate utilities in the `boot.pod` and `boot.util` namespaces.  I needed the `canonical-id` utility in `boot.util`, so I've moved all of the related functions there.  I've created aliases in the `boot.pod` namespace for backwards compatibility.  I haven't marked these as deprecated, but that would be a possibility.  Note that I've also mapped `coord->map` and `map->coord` to `util/dep-as-map` and `util/map-as-dep`, which provide more correct implementations. 

 * Tests have been provided for nearly all of the new functions.  I also had to correct tests in `boot.pod-test` related to the constructors for filesets. The fileset tests pass now, but I haven't verified that they do something reasonable. The tests can be run by hand, but don't appear to run automatically from the Makefile build.

 * One detail that I don't like is that I had to deal with an added path differently from an added dependency when creating the pod to isolate these changes.  Perhaps this is a misunderstanding on my part, but I expected just adding a new source path to the environment before creating the pod would update the pod's classpath.  This didn't work, do I've updated the classpath explicitly in the `read-deps` function. 

I'd be interested in feedback on the feature and its implementation.  This works well for my use case, but I'd like to understand if there's something I can change to ensure it is as widely useful as possible. 

 