### PR TITLE
Add line numbers to -b option

### DIFF
--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -189,7 +189,10 @@
               import-ns   (export-task-namespaces initial-env)
               scriptforms (emit boot? args userforms localforms bootforms import-ns (:init opts))
               scriptstr   (binding [*print-meta* true]
-                            (str (string/join "\n\n" (map pr-boot-form scriptforms)) "\n"))]
+                            (str (->> scriptforms
+                                     (map pr-boot-form)
+                                     (map-indexed (fn [i form] (format "%s %s" i form)))
+                                     (string/join "\n\n")) "\n"))]
 
           (when (:boot-script opts) (util/exit-ok (print scriptstr)))
 


### PR DESCRIPTION
I was taking a stab at adding the line number in `-b` for debugging purposes, it looked like a nice and easy feature to add, but I noticed that, while debugging an error I have, sometimes the error reports the line as in "one line per form" and sometimes it just reports the last line number.

Example: `data: {:file "/tmp/boot.user3358451832744193056.clj", :line 97}` where `boot -b|wc -l` is `97`.

So maybe I need a bit more digging and guidance on this one. Also, maybe you guys already tried and abandoned the idea?