### PR TITLE
Fix boot.pod/canonical-id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ deploy: .deployed
 
 .tested: bin/boot
 	(export BOOT_VERSION=$(version) && export BOOT_EMIT_TARGET=no && cd boot/core && ../../bin/boot -x test)
+    # (cd boot/pod && lein test)
 	date > .tested
 
 test: .installed .tested

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -508,12 +508,13 @@
   as the namespace of the resulting symbol only if it's not the same as the
   artifact id.
 
-  For example: (canonical-id 'foo/foo) ;=> foo
-               (canonical-id 'foo/bar) ;=> foo/bar"
+  Examples: (canonical-id 'foo) ;=> 'foo
+            (canonical-id 'foo/foo) ;=> 'foo
+            (canonical-id 'foo/bar) ;=> 'foo/bar"
   [id]
   (when id
     (let [[ns nm] ((juxt namespace name) id)]
-      (if (not= ns nm) id))))
+      (if (not= ns nm) (symbol id) (symbol nm)))))
 
 (defn full-id
   "Given a project id symbol, returns the fully qualified form, with the group


### PR DESCRIPTION
There are a couple of failing tests in `boot/pod/test/pod_test.clj` but I haven't had time to investigate further. After that, the:

`(cd boot/pod && lein test)`

can be decommented so that `make test` runs also those ones.
