### PR TITLE
Prevent play! from throwing on systems with no audio output

### DIFF
--- a/boot/worker/src/boot/notify.clj
+++ b/boot/worker/src/boot/notify.clj
@@ -17,13 +17,17 @@
 
 (defn play! [file]
   (fg-first-time!
-    (future
-      (-> (or (.getResourceAsStream (clojure.lang.RT/baseLoader) file)
-            (FileInputStream. (io/file file))
-            (or (throw (RuntimeException. (str file " not found.")))))
-        java.io.BufferedInputStream.
-        javazoom.jl.player.Player.
-        .play))))
+   (future
+     (try
+       (-> (or (.getResourceAsStream (clojure.lang.RT/baseLoader) file)
+               (FileInputStream. (io/file file))
+               (throw (RuntimeException. (str file " not found."))))
+           java.io.BufferedInputStream.
+           javazoom.jl.player.Player.
+           .play)
+       (catch Exception e
+         (util/warn "\nError attempting to play sound file: %s\n\n"
+                    (.getMessage e)))))))
 
 (defn success! [theme file] (play! (or file (path-for theme "success"))))
 (defn failure! [theme file] (play! (or file (path-for theme "failure"))))


### PR DESCRIPTION
I chose to catch `JavaLayerException` because that constrains the types of
errors that will be caught to those originating inside of Java Layer.

It's possible that we could detect the presence/absence of an audio
device using the Java Sound API AudioSystem, but it's not clear to me
that would be more robust.  This will probably also catch problems like
trying to play a format that is not supported by Java Layer.

Closes #520.