### PR TITLE
use pomegranate for managed dependencies

### DIFF
--- a/boot/aether/project.clj
+++ b/boot/aether/project.clj
@@ -16,5 +16,5 @@
   :dependencies [[org.clojure/clojure               "1.6.0"  :scope "compile"]
                  [boot/base                         ~version :scope "provided"]
                  [boot/pod                          ~version :scope "compile"]
-                 [com.cemerick/pomegranate          "0.3.0"  :scope "compile"]
+                 [com.cemerick/pomegranate          "0.3.1"  :scope "compile"]
                  [org.apache.maven.wagon/wagon-http "2.9"    :scope "compile"]])

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -104,6 +104,7 @@
   [env]
   (try
     (aether/resolve-dependencies
+      :managed-coordinates (:managed-dependencies env)
       :coordinates       (:dependencies env)
       :repositories      (->> (or (seq (:repositories env)) @default-repositories)
                            (map (juxt first (fn [[x y]] (if (map? y) y {:url y}))))


### PR DESCRIPTION
Allow boot users to specify a set of managed dependencies (under the `:managed-dependencies` key) as well as the existing `:dependencies`.  Pomegranate uses the managed dependency information to complete any missing versions in the dependencies and may be used to influence the versions for transient dependencies.  This feature is useful when trying to maintain a set of consistent dependency versions across a number of different projects.
