### PR TITLE
Update to dynapath 0.2.4

### DIFF
--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -17,5 +17,5 @@
                    :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies   [[boot/base                               ~version :scope "provided"]
                    [org.clojure/clojure                     "1.6.0"  :scope "provided"]
-                   [org.tcrawley/dynapath                   "0.2.3"  :scope "compile"]
+                   [org.tcrawley/dynapath                   "0.2.4"  :scope "compile"]
                    [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]])


### PR DESCRIPTION
0.2.4 does work properly under Java 9.

0.2.3 makes invalid assumptions about the classloader tree.