### PR TITLE
Add --mode option to built in target task

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## Master
+
+##### Task Options
+- Added `-m, --mode` option to the `target` task &mdash; specifies the file
+  mode for written files &mdash; should only be used when default `rw-------`
+  is not enough.
+
 ## 2.7.0
 
 #### Improved

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -1002,10 +1002,10 @@
   (let [prev   (atom nil)
         clean! (if clean empty-dir! identity)
         dirs   (delay (mapv #(doto (io/file %) .mkdirs clean!) dirs))]
-    (fn [fs & {:keys [link]}]
+    (fn [fs & {:keys [link mode]}]
       (let [link  (when link :tmp)
             [a b] [@prev (reset! prev (output-fileset fs))]]
-        (mapv deref (for [d @dirs :let [p! (partial fs/patch! (fs/->path d) a b :link)]]
+        (mapv deref (for [d @dirs :let [p! (partial fs/patch! (fs/->path d) a b :mode mode :link)]]
                       (future (try (p! link)
                                    (catch Throwable t
                                      (if-not link (throw t) (p! nil)))))))))))

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -365,7 +365,9 @@
 (defn- mk-posix-file-permissions [posix-string]
   (try
     (when posix-string
-      (PosixFilePermissions/fromString posix-string))
+      (if (boot.App/isWindows)
+        (util/warn "Filemode not supported on Windows\n")
+        (PosixFilePermissions/fromString posix-string)))
     (catch IllegalArgumentException _
       (util/warn "Could not parse mode string, ignoring...\n"))))
 

--- a/boot/pod/src/boot/file.clj
+++ b/boot/pod/src/boot/file.clj
@@ -21,10 +21,14 @@
 (def ^:dynamic *sync-delete* true)
 (def ^:dynamic *hard-link*   true)
 
+(def windows? (boot.App/isWindows))
+
 (def tmpfile-permissions
   (into-array FileAttribute
-              [(PosixFilePermissions/asFileAttribute
-                 (PosixFilePermissions/fromString "rw-------"))]))
+              (if windows?
+                []
+                [(PosixFilePermissions/asFileAttribute
+                  (PosixFilePermissions/fromString "rw-------"))])))
 
 (defn file? [f] (when (try (.isFile (io/file f)) (catch Throwable _)) f))
 (defn dir? [f] (when (try (.isDirectory (io/file f)) (catch Throwable _)) f))
@@ -247,8 +251,7 @@
 
 (defn match-filter?
   [filters f]
-  (let [windows?  (boot.App/isWindows)
-        normalize #(if-not windows? % (str/replace % #"\\" "/"))]
+  (let [normalize #(if-not windows? % (str/replace % #"\\" "/"))]
     ((apply some-fn (map (partial partial re-find) filters)) (normalize (.getPath ^File f)))))
 
 (defn keep-filters?

--- a/boot/pod/src/boot/filesystem.clj
+++ b/boot/pod/src/boot/filesystem.clj
@@ -38,6 +38,8 @@
 (def read-only
   (PosixFilePermissions/fromString "r--r--r--"))
 
+(def windows? (boot.App/isWindows))
+
 (defprotocol IToPath
   (->path [x] "Returns a java.nio.file.Path for x."))
 
@@ -160,7 +162,7 @@
     (util/dbug* "Filesystem: copying %s...\n" (string/join "/" path))
     (try (Files/copy ^Path src ^Path dst copy-opts)
          (Files/setLastModifiedTime dst (FileTime/fromMillis time))
-         (when mode (Files/setPosixFilePermissions dst mode))
+         (when (and mode (not windows?)) (Files/setPosixFilePermissions dst mode))
          (catch java.nio.file.NoSuchFileException ex
            (util/dbug* "Filesystem: %s\n", (str ex))))))
 
@@ -170,7 +172,7 @@
     (util/dbug* "Filesystem: linking %s...\n" (string/join "/" path))
     (try (Files/deleteIfExists dst)
          (Files/createLink (doto dst mkparents!) src)
-         (when mode (Files/setPosixFilePermissions dst mode))
+         (when (and mode (not windows?)) (Files/setPosixFilePermissions dst mode))
          (catch java.nio.file.NoSuchFileException ex
            (util/dbug* "Filesystem: %s\n" (str ex))))))
 


### PR DESCRIPTION
For situations where the default 'rw-------' file modes are not enough,
a (posix) mode string can be given to target. All files will get the 
mode written.

When an invalid mode is given, a warning is printed and standard 
permissions will be used.