### PR TITLE
Improvements to work with Java 9

### DIFF
--- a/boot/base/src/main/java/boot/AddableClassLoader.java
+++ b/boot/base/src/main/java/boot/AddableClassLoader.java
@@ -1,0 +1,14 @@
+package boot;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+// Allows us to have a modifiable ClassLoader without having to call
+// .setAccessible on URLClassLoader.addURL(), since that's not allowed
+// by default under Java 9
+public class AddableClassLoader extends URLClassLoader {
+    public AddableClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent); }
+    
+    public void addURL(URL url) {
+	super.addURL(url); }}

--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -7,7 +7,6 @@ import java.nio.channels.FileLock;
 import java.nio.channels.FileChannel;
 import java.lang.ref.WeakReference;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Date;
 import java.util.UUID;
@@ -306,7 +305,7 @@ public class App {
 
         for (int i=0; i<jarFiles.length; i++) urls[i] = jarFiles[i].toURI().toURL();
 
-        ClassLoader cl = new URLClassLoader(urls, App.class.getClassLoader());
+        ClassLoader cl = new AddableClassLoader(urls, App.class.getClassLoader());
         ClojureRuntimeShim rt = ClojureRuntimeShim.newRuntime(cl);
 
         rt.setName(name != null ? name : "anonymous");
@@ -319,6 +318,7 @@ public class App {
 
         rt.require("boot.pod");
         rt.invoke("boot.pod/seal-app-classloader");
+        rt.invoke("boot.pod/extend-addable-classloader");
         rt.invoke("boot.pod/set-data!", data);
         rt.invoke("boot.pod/set-pods!", pods);
         rt.invoke("boot.pod/set-this-pod!", new WeakReference<ClojureRuntimeShim>(rt));

--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -17,5 +17,5 @@
                    :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies   [[boot/base                               ~version :scope "provided"]
                    [org.clojure/clojure                     "1.6.0"  :scope "provided"]
-                   [org.tcrawley/dynapath                   "0.2.4"  :scope "compile"]
+                   [org.tcrawley/dynapath                   "0.2.5"  :scope "compile"]
                    [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]])


### PR DESCRIPTION
Changes include:

* update to dynapath 0.2.5 (0.2.4 was broken when AOT'd under < Java 9,
  but used under Java 9)
* conditionally seal the AppClassLoader if it is available (it isn't
  under Java 9)
* seal the new ParentClassLoader from boot-bin
* use a URLClassLoader subclass that exposes .addURL so it can be
  modified (we can't call .setAccessible on URLClassLoader.addURL by
  default under Java 9) as the highest loader in the shim

This is part of the fix; https://github.com/boot-clj/boot-bin/pull/4 is the other half. These changes *shouldn't* break users using a `boot.sh` without PR4. 

Let me know if this (or the approach in PR4) aren't appropriate, and I'm happy to discuss more here or on slack.