### PR TITLE
Use the new CDN-backed clojars repo by default

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -22,7 +22,7 @@
 (def local-repo           (atom nil))
 (def default-repositories (delay (let [c (boot.App/config "BOOT_CLOJARS_REPO")
                                        m (boot.App/config "BOOT_MAVEN_CENTRAL_REPO")]
-                                   [["clojars"       {:url (or c "https://clojars.org/repo/")}]
+                                   [["clojars"       {:url (or c "https://repo.clojars.org/")}]
                                     ["maven-central" {:url (or m "https://repo1.maven.org/maven2/")}]])))
 (def default-mirrors      (delay (let [c (boot.App/config "BOOT_CLOJARS_MIRROR")
                                        m (boot.App/config "BOOT_MAVEN_CENTRAL_MIRROR")

--- a/boot/base/pom.in.xml
+++ b/boot/base/pom.in.xml
@@ -32,7 +32,7 @@
     </repository>
     <repository>
       <id>clojars</id>
-      <url>https://clojars.org/repo/</url>
+      <url>https://repo.clojars.org/</url>
     </repository>
     <repository>
       <id>maven-central</id>

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -58,7 +58,7 @@
 (def ^:private repo-config-fn    (atom identity))
 (def ^:private loaded-checkouts  (atom {}))
 (def ^:private checkout-dirs     (atom #{}))
-(def ^:private default-repos     [["clojars"       {:url "https://clojars.org/repo/"}]
+(def ^:private default-repos     [["clojars"       {:url "https://repo.clojars.org/"}]
                                   ["maven-central" {:url "https://repo1.maven.org/maven2"}]])
 (def ^:private default-mirrors   (delay (let [c (boot.App/config "BOOT_CLOJARS_MIRROR")
                                               m (boot.App/config "BOOT_MAVEN_CENTRAL_MIRROR")


### PR DESCRIPTION
This also changes the mvn portion of the build to use it as well. Note
that this new repo does not support Java 6. With this change, Java 6
users will have to override the repo manually back to the old value.