### PR TITLE
New task: socket-server

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -479,6 +479,29 @@
           (core/with-post-wrap [_]
             (when (or client (not server)) @repl-cli)))))
 
+(core/deftask socket-server
+  "Start a socket server.
+
+  The default behavior is to serve a simple REPL handled by
+  clojure.core.server/repl. To serve a different handler function, specify a
+  symbol using `--accept'.
+
+  If no bind address is specified, the socket server will listen on 127.0.0.1.
+
+  If no port is specified, an open port will be chosen automatically. The port
+  number is written to .socket-port in the current directory.
+
+  The REPL can be accessed with the command
+
+     $ nc localhost $(cat .server-port)"
+
+  [b bind ADDR      str    "The address server listens on."
+   p port PORT      int    "The port to listen to."
+   a accept ACCEPT  sym    "Namespaced symbol of the accept function to invoke."]
+  (let [repl-soc (delay (repl/launch-socket-server *opts*))]
+    (core/with-pass-thru [fs]
+      @repl-soc)))
+
 (core/deftask pom
   "Create project pom.xml file.
 


### PR DESCRIPTION
Exposes the Socket Server functionality available in Clojure 1.8 or above as a new task. By default, the handler function is clojure.core.server/repl, but a different handler can be specified.

This is useful because Clojure's standard way of enabling the socket server, by setting a system property, doesn't work well with boot (https://github.com/boot-clj/boot/issues/453).

Wheres `boot repl --server`, provides nREPL functionality used in CIDER, `boot socket-server` can be used e.g. with Emacs's inf-clojure mode. It starts up much faster than `boot repl --server` (12s vs 80s), and is more easily accessible using `nc` or `telnet`. But compared to REPLy it is pretty bare-bones and doesn't provide advanced features like auto-completion or beautiful stack traces.

This commit adds a new task rather than extending `repl`. The reason is that Socket Servers provides not just REPL but server functionality in general, and that `repl` semantics are already confusing because of how `--server` and `--client` flags work.

Like `repl`, `socket-server` defaults to picking a port at random and stores it in a file, .socket-port, in the current directory.

Fixes #453