### PR TITLE
Improve robustness and formatting for `notify` built-in

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -174,11 +174,11 @@
             (throw t)))))))
 
 (core/deftask ^{:boot/from :jeluard/boot-notify} notify
-  "Aural and visual notifications during build.
+  "Audible and visual notifications during build.
 
-  Default audio themes: system (the default), ordinance, pillsbury,
-  and woodblock. New themes can be included via jar dependency with
-  the sound files as resources:
+  Default audio themes: system (the default), ordinance, pillsbury and
+  woodblock. New themes can be included via jar dependency with the
+  sound files as resources:
 
       boot
       └── notify
@@ -189,8 +189,8 @@
   Sound files specified individually take precedence over theme sounds.
 
   For visual notifications, there is a default implementation that
-  tries to use the `terminal-notifier' program on OS X systems, and
-  the `notify-send' program on Linux systems.
+  tries to use the `terminal-notifier' or `osascript` programs on OS X
+  systems, and the `notify-send' program on Linux systems.
 
   You can also supply custom notification functions via the *-notify-fn
   options. Both are functions that take one argument which is a map of
@@ -200,7 +200,14 @@
   - :type, :file, and :theme.
 
   The visual notification function will receive a map with four keys
-  - :title, :uid, :icon, and :message."
+  - :title, :uid, :icon, and :message.
+
+  The `notify` task always attempts to catch any exceptions that are
+  thrown so as not to cause your build to fail. If no notifications
+  are happening even if you specify `audible` or `visual`, you can see
+  any exceptions that are being caught by changing
+  `boot.util/*verbosity*` (at the command-line use: `boot -v` or `boot
+  -vv`)."
 
   [a audible                    bool      "Play an audible notification"
    v visual                     bool      "Display a visual notification"

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -215,7 +215,8 @@
 
   (let [themefiles (notify/get-themefiles theme (core/tmp-dir!))
         sounds (merge themefiles soundfiles)
-        base-visual-opts {:title (or title "Boot")
+        title (or title "Boot")
+        base-visual-opts {:title title
                           :uid   (or uid title)
                           :icon  (or icon (notify/boot-logo))}
         messages (merge {:success "Success!" :warning "%s warning/s" :failure "%s"}

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -27,7 +27,7 @@
   (util/warn
    "An exception was thrown while trying to send a notification. To see more info, increase the verbosity of your build with e.g. \"boot -v\" or \"boot -vv\"\n"))
 
-(defn sh-with-timeout [& args]
+(defn- sh-with-timeout [& args]
   (try
     (apply util/dosh-timed 1000 args)
     0
@@ -37,9 +37,15 @@
         (util/print-ex e))
       1)))
 
+(defn- warn-program-not-found [program-name]
+  (util/warn "Could not find the '%s' program on PATH.\n" program-name)
+  false)
+
 (defn- ^{:boot/from :jeluard/boot-notify} program-exists?
-  [s]
-  (= 0 (sh-with-timeout "sh" "-c" (format "command -v %s >/dev/null" s))))
+  [program-name]
+  (or
+   (= 0 (sh-with-timeout "sh" "-c" (format "command -v %s >/dev/null" program-name)))
+   (warn-program-not-found program-name)))
 
 (defn- try-notify-with-shell-program [program-name & args]
   (and

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -37,9 +37,20 @@
 (defn- escape [s]
   (pr-str (str s)))
 
+(defn- notify-default [{:keys [message title]}]
+  (util/info "%s%s %s \u2022 %s\n"
+             ansi/reset-font
+             (ansi/italic "notification:")
+             (ansi/bold title)
+             message))
+
 (defmulti notify-method
-  (fn [os _message]
+  (fn [os _notification]
     os))
+
+(defmethod notify-method :default
+  [_ notification]
+  (notify-default notification))
 
 (defmethod notify-method "Mac OS X"
   [_ {:keys [message title icon uid] :as notification}]
@@ -62,7 +73,7 @@
           (escape title)))
 
     :else
-    ((get-method notify-method :default) :default notification)))
+    (notify-default notification)))
 
 (defmethod notify-method "Linux"
   [_ {:keys [message title icon] :as notification}]
@@ -73,15 +84,7 @@
      (str message)
      "--icon"
      (str icon))
-    ((get-method notify-method :default) :default notification)))
-
-(defmethod notify-method :default
-  [_ {:keys [message title]}]
-  (util/info "%s%s %s \u2022 %s\n"
-             ansi/reset-font
-             (ansi/italic "notification:")
-             (ansi/bold title)
-             message))
+    (notify-default notification)))
 
 (defn ^{:boot/from :jeluard/boot-notify} visual-notify!
   [data]

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -2,7 +2,9 @@
   (:require [clojure.java.io    :as io]
             [clojure.java.shell :as shell]
             [boot.core          :as core]
-            [boot.pod           :as pod]))
+            [boot.pod           :as pod]
+            [boot.util          :as util]
+            [boot.from.io.aviso.ansi :as ansi]))
 
 (defn get-themefiles [theme tmp-dir]
   (let [resource   #(vector %2 (format "boot/notify/%s_%s.mp3" %1 %2))
@@ -66,7 +68,11 @@
 
 (defmethod notify-method :default
   [_ {:keys [message title]}]
-  (printf "%s: %s" title message))
+  (util/info "%s%s %s \u2022 %s\n"
+             ansi/reset-font
+             (ansi/italic "notification:")
+             (ansi/bold title)
+             message))
 
 (defn ^{:boot/from :jeluard/boot-notify} visual-notify!
   [data]

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -27,7 +27,8 @@
   (try
     (apply util/dosh-timed 1000 args)
     0
-    (catch Exception _
+    (catch Exception e
+      (util/print-ex e)
       1)))
 
 (defn- ^{:boot/from :jeluard/boot-notify} program-exists?

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -23,12 +23,18 @@
     (io/copy (io/input-stream (io/resource "boot-logo-3.png")) f)
     (.getAbsolutePath f)))
 
+(defn- warn-ex-thrown []
+  (util/warn
+   "An exception was thrown while trying to send a notification. To see more info, increase the verbosity of your build with e.g. \"boot -v\" or \"boot -vv\"\n"))
+
 (defn sh-with-timeout [& args]
   (try
     (apply util/dosh-timed 1000 args)
     0
     (catch Exception e
-      (util/print-ex e)
+      (if (= 1 @util/*verbosity*)
+        (warn-ex-thrown)
+        (util/print-ex e))
       1)))
 
 (defn- ^{:boot/from :jeluard/boot-notify} program-exists?

--- a/boot/core/src/boot/task_helpers/notify.clj
+++ b/boot/core/src/boot/task_helpers/notify.clj
@@ -33,13 +33,21 @@
 (defmethod notify-method "Mac OS X"
   [_ {:keys [message title icon uid] :as notification}]
   (if (program-exists? "terminal-notifier")
-    (shell/sh "terminal-notifier" "-message" message "-title" title "-contentImage" icon "-group" uid)
+    (shell/sh "terminal-notifier"
+              "-message" (str message)
+              "-title" (str title)
+              "-contentImage" (str icon)
+              "-group" (str uid))
     ((get-method notify-method :default) :default notification)))
 
 (defmethod notify-method "Linux"
   [_ {:keys [message title icon] :as notification}]
   (if (program-exists? "notify-send")
-    (shell/sh "notify-send" title message "--icon" icon)
+    (shell/sh "notify-send"
+              (str title)
+              (str message)
+              "--icon"
+              (str icon))
     ((get-method notify-method :default) :default notification)))
 
 (defmethod notify-method :default


### PR DESCRIPTION
There are a number of separate improvements here:

- The fallback behavior for the `uid` key was incorrect (fixes #550)
- Added logic to prevent user passed options from causing a similar error to be thrown from `shell/sh` again
- Added  a median fallback option for MacOS of displaying a notification with AppleScript
- Finally, improved the visual design of the ultimate fallback visual notification system (printing to the console)