### PR TITLE
ensure title is not nil when setting default for uid in notify

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -215,7 +215,8 @@
 
   (let [themefiles (notify/get-themefiles theme (core/tmp-dir!))
         sounds (merge themefiles soundfiles)
-        base-visual-opts {:title (or title "Boot")
+        title (or title "Boot")
+        base-visual-opts {:title title
                           :uid   (or uid title)
                           :icon  (or icon (notify/boot-logo))}
         messages (merge {:success "Success!" :warning "%s warning/s" :failure "%s"}


### PR DESCRIPTION
I noticed that the notify task throws an exception when `:visual` is true and `:title` is not explicitly set on Mac OS X. The reason for this is that when the `base-visual-opts` map is constructed, the `:uid` is defaulted to the value of `title`, but if `title` is nil, then `uid` will also be nil. This PR ensures that `title` is not nil when used as the default value for `uid`.