### PR TITLE
Allow disabling of inotify.

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -45,6 +45,7 @@
                  ["" "BOOT_FILE"                 "Build script name (build.boot)."]
                  ["" "BOOT_GPG_COMMAND"          "System gpg command (gpg)."]
                  ["" "BOOT_HOME"                 "Directory where boot stores global state (~/.boot)."]
+                 ["" "BOOT_WATCHERS_DISABLE"      "Set to 'yes' to turn off inotify/FSEvents watches."]
                  ["" "BOOT_JAVA_COMMAND"         "Specify the Java executable (java)."]
                  ["" "BOOT_JVM_OPTIONS"          "Specify JVM options (Unix/Linux/OSX only)."]
                  ["" "BOOT_LOCAL_REPO"           "The local Maven repo path (~/.m2/repository)."]

--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -17,6 +17,20 @@
 
 (declare print-ex)
 
+(defn watchers?-system-default
+  "Return whether we should register file watches on this
+  system. Constrained environments like clould build containers limit
+  the number of inotify handles, and watchers are only necessary for
+  interactive dev, not one-shot jobs.  environment variable or
+  configuration option BOOT_WATCHERS_DISABLE to either '1' or 'yes' to
+  disable inotify; any other value keeps normal behavior."
+  []
+  (let [value (boot.App/config "BOOT_WATCHERS_DISABLE")]
+    (if (string/blank? value)
+      true
+      (not (#{"1" "yes"}
+            (string/lower-case value))))))
+
 (defn colorize?-system-default
   "Return whether we should colorize output on this system. The default
   console on Windows does not interprete ANSI escape codes, so colorized
@@ -49,6 +63,10 @@
   "Atom containing the value that determines whether ANSI colors escape codes
   will be printed with boot output."
   (atom (colorize?-system-default)))
+
+(def ^:dynamic *watchers?*
+  "Atom containing the value that determines whether inotify watches are registered"
+  (atom (watchers?-system-default)))
 
 (defn- print*
   [verbosity color args]

--- a/boot/worker/src/boot/watcher.clj
+++ b/boot/worker/src/boot/watcher.clj
@@ -58,11 +58,12 @@
 
 (defn- register-recursive
   [service path events]
-  (util/dbug* "registering %s %s\n" path events)
-  (register service path events)
-  (doseq [dir (.listFiles (io/file path))]
-    (when (.isDirectory dir)
-      (register-recursive service dir events))))
+  (when @util/*watchers?*
+    (util/dbug* "registering %s %s\n" path events)
+    (register service path events)
+    (doseq [dir (.listFiles (io/file path))]
+      (when (.isDirectory dir)
+        (register-recursive service dir events)))))
 
 (defn- new-watch-service []
   (if (= "Mac OS X" (System/getProperty "os.name"))


### PR DESCRIPTION
Workaround for https://github.com/boot-clj/boot/issues/530 - CircleCI inotify exhaustion

Adds a `BOOT_WATCHERS_DISABLE` env variable and property.  

Adds a `--disable-watchers` cli flag that is transferred to a worker pod.

Kills the directory recursion for adding watches based on the value of `boot.util/*watchers?*`.

Tested with the inotify debug script here: https://readmes.numm.org/init/upstart/init/tests/wrap_inotify.c

Repro instructions:
1) compile C file above
```
 $ gcc -c -fPIC wrap_inotify.c -o wrap_inotify.o
 $ gcc wrap_inotify.o -shared -o libwrapinotify.so
```

2) Run boot build with flag and env variable.  INOTIFY_DEBUG will show watches being added.

```
LD_PRELOAD=./libwrapinotify.so INOTIFY_DEBUG=true boot build
``` 

3) Run with flags and env vars and properties.  Note that inotify is enabled but no watches are added in debug output.
```
LD_PRELOAD=./libwrapinotify.so INOTIFY_DEBUG=true boot --disable-watchers build
``` 
```
LD_PRELOAD=./libwrapinotify.so INOTIFY_DEBUG=true BOOT_WATCHERS_DISABLE boot build
``` 