### PR TITLE
Correctly diff nested data structures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - `set-env!` works even if the user has set `*print-level*` or `*print-length*` to non-nil in their `$BOOT_HOME/profile.boot`. [#587][587] [#586][586]
 - `tmpfile` "Commit: adding..." messages now only appear with `-vv` which eases debugging tasks with `-v` [#557][557]
 - Pod tests pass and can be run with `make` [#567][567]
+- `fileset-diff` correctly handles nested data structions [#566][566]
 
 #### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 - `set-env!` works even if the user has set `*print-level*` or `*print-length*` to non-nil in their `$BOOT_HOME/profile.boot`. [#587][587] [#586][586]
 - `tmpfile` "Commit: adding..." messages now only appear with `-vv` which eases debugging tasks with `-v` [#557][557]
 - Pod tests pass and can be run with `make` [#567][567]
-- `fileset-diff` correctly handles nested data structions [#566][566]
+- `fileset-diff` correctly handles nested data structures [#566][566]
 
 #### Fixed
 

--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -213,10 +213,11 @@
     (let [props   (or (seq props) [:id])
           d1      (diff-tree t1 props)
           d2      (diff-tree t2 props)
-          [x y _] (map (comp set keys) (data/diff d1 d2))]
-      {:added   (->> (set/difference   y x) (select-keys t2) (assoc after :tree))
-       :removed (->> (set/difference   x y) (select-keys t1) (assoc after :tree))
-       :changed (->> (set/intersection x y) (select-keys t2) (assoc after :tree))})))
+          [x y z] (map (comp set keys) (data/diff d1 d2))
+          changed-keys (set/union (set/intersection x y) (set/intersection (set/union x y) z))]
+      {:added   (->> (set/difference y x changed-keys) (select-keys t2) (assoc after :tree))
+       :removed (->> (set/difference x y changed-keys) (select-keys t1) (assoc after :tree))
+       :changed (->> changed-keys                      (select-keys t2) (assoc after :tree))})))
 
 (defn- fatal-conflict?
   [^File dest]

--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -207,7 +207,7 @@
 (defn- diff*
   [{t1 :tree :as before} {t2 :tree :as after} props]
   (if-not before
-    {:added   after
+    {:added   (or after {:tree {}})
      :removed (assoc after :tree {})
      :changed (assoc after :tree {})}
     (let [props   (or (seq props) [:id])

--- a/boot/pod/test/boot/tmpdir_test.clj
+++ b/boot/pod/test/boot/tmpdir_test.clj
@@ -1,0 +1,61 @@
+(ns boot.tmpdir-test
+  (:refer-clojure :exclude [hash time])
+  (:require
+    [clojure.test :refer :all]
+    [boot.tmpdir :as tmpd]))
+
+(defn has-path? [fs path]
+  (contains? (:tree fs) path))
+
+(deftest diff*-scalar-test
+  (let [before (tmpd/map->TmpFileSet {:tree {}})
+        after (tmpd/map->TmpFileSet {:tree {"path" {:adding true}}})
+        diff (#'tmpd/diff* before after [:adding])]
+    (testing "Added"
+      (is (has-path? (:added diff) "path"))
+      (is (not (has-path? (:removed diff) "path")))
+      (is (not (has-path? (:changed diff) "path")))))
+  (let [before (tmpd/map->TmpFileSet {:tree {"path" {:removing true}}})
+        after (tmpd/map->TmpFileSet {:tree {}})
+        diff (#'tmpd/diff* before after [:removing])]
+    (testing "Removed"
+      (is (has-path? (:removed diff) "path"))
+      (is (not (has-path? (:added diff) "path")))
+      (is (not (has-path? (:changed diff) "path")))))
+  (let [before (tmpd/map->TmpFileSet {:tree {"path" {:changing true}}})
+        after (tmpd/map->TmpFileSet {:tree {"path" {:changing false}}})
+        diff (#'tmpd/diff* before after [:changing])]
+    (testing "Changed"
+      (is (has-path? (:changed diff) "path"))
+      (is (not (has-path? (:added diff) "path")))
+      (is (not (has-path? (:removed diff) "path"))))))
+
+(deftest diff*-nested-test
+  (let [before (tmpd/map->TmpFileSet {:tree {}})
+        after (tmpd/map->TmpFileSet {:tree {"path" {:nested {:adding true}}}})
+        diff (#'tmpd/diff* before after [:nested])]
+    (testing "Added"
+      (is (has-path? (:added diff) "path"))
+      (is (not (has-path? (:removed diff) "path")))
+      (is (not (has-path? (:changed diff) "path")))))
+  (let [before (tmpd/map->TmpFileSet {:tree {"path" {:nested {:removing true}}}})
+        after (tmpd/map->TmpFileSet {:tree {}})
+        diff (#'tmpd/diff* before after [:nested])]
+    (testing "Removed"
+      (is (has-path? (:removed diff) "path"))
+      (is (not (has-path? (:added diff) "path")))
+      (is (not (has-path? (:changed diff) "path")))))
+  (let [before (tmpd/map->TmpFileSet {:tree {"path" {:nested {:changing true}}}})
+        after (tmpd/map->TmpFileSet {:tree {"path" {:nested {:changing false}}}})
+        diff (#'tmpd/diff* before after [:nested])]
+    (testing "Changed (simple)"
+      (is (has-path? (:changed diff) "path"))
+      (is (not (has-path? (:added diff) "path")))
+      (is (not (has-path? (:removed diff) "path")))))
+  (let [before (tmpd/map->TmpFileSet {:tree {"path" {:nested {:staying true :changing true}}}})
+        after (tmpd/map->TmpFileSet {:tree {"path" {:nested {:staying true :changing false}}}})
+        diff (#'tmpd/diff* before after [:nested])]
+    (testing "Changed (complex)"
+      (is (has-path? (:changed diff) "path"))
+      (is (not (has-path? (:added diff) "path")))
+      (is (not (has-path? (:removed diff) "path"))))))

--- a/boot/pod/test/boot/tmpdir_test.clj
+++ b/boot/pod/test/boot/tmpdir_test.clj
@@ -59,3 +59,19 @@
       (is (has-path? (:changed diff) "path"))
       (is (not (has-path? (:added diff) "path")))
       (is (not (has-path? (:removed diff) "path"))))))
+
+(deftest diff*-edge-test
+  (let [before {}
+        after {}
+        diff (#'tmpd/diff* before after)]
+    (testing "Empty dicts"
+      (is (empty? (:added diff)))
+      (is (empty? (:removed diff)))
+      (is (empty? (:changed diff)))))
+  (let [before nil
+        after nil
+        diff (#'tmpd/diff* before after)]
+    (testing "Nil"
+      (is (empty? (:added diff)))
+      (is (empty? (:removed diff)))
+      (is (empty? (:changed diff))))))

--- a/boot/pod/test/boot/tmpdir_test.clj
+++ b/boot/pod/test/boot/tmpdir_test.clj
@@ -63,15 +63,17 @@
 (deftest diff*-edge-test
   (let [before {}
         after {}
-        diff (#'tmpd/diff* before after)]
+        diff (#'tmpd/diff* before after [:hash :time])
+        empty-fs {:tree {}}]
     (testing "Empty dicts"
-      (is (empty? (:added diff)))
-      (is (empty? (:removed diff)))
-      (is (empty? (:changed diff)))))
+      (is (= empty-fs (:added diff)))
+      (is (= empty-fs (:removed diff)))
+      (is (= empty-fs (:changed diff)))))
   (let [before nil
         after nil
-        diff (#'tmpd/diff* before after)]
+        diff (#'tmpd/diff* before after [:hash :time])
+        empty-fs {:tree {}}]
     (testing "Nil"
-      (is (empty? (:added diff)))
-      (is (empty? (:removed diff)))
-      (is (empty? (:changed diff))))))
+      (is (= empty-fs (:added diff)))
+      (is (= empty-fs (:removed diff)))
+      (is (= empty-fs (:changed diff))))))


### PR DESCRIPTION
## Summary

I would like to do `(boot.core/fileset-diff old-fs new-fs :foo)`, where the `:foo` key is a nested data structure set on tmpfiles in the filesets, but this currently only works in some cases. While the current implementation of `fileset-diff` works well for diffing scalar values, the semantics are not correct for diffing nested structures. This small modification results in correct diffs for nested structures, which is useful when using custom tmpfile metadata.

## Explanation

The root of the problem is that, in `boot.tmpdir/diff*`, only the first two return values of `clojure.data/diff` are used to calculate changes. For scalars, this is all that's necessary, but nested compound data structures require the use of the third value as well. For example, if you were to diff the following metadata structures, the 3rd value comes into play:

```clojure
user> (data/diff {"path" {:foo {:stays true :goes false}}}
                 {"path" {:foo {:stays true}}})
({"path" {:foo {:goes false}}} nil {"path" {:foo {:stays true}}})
```

`diff*` should return this in the `:changed` fileset, but it currently registers as `:removed`. A similar interaction results in nested key additions registering as `:added` instead of `:changed`.

If the return value of `data/diff` is `[x y z]`, then `:changed` should include all paths that are in both `x` and `y`, plus all keys that are in `x` or `y` (or both) and in `z`.  Following on from that, `:added` and `:removed` should not contain any paths that are in `:changed`.