### PR TITLE
use macro to avoid expensive pprint evaluation

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -68,7 +68,7 @@
 
 (defn transfer-listener
   [info]
-  (util/dbug "Aether: %s\n" (with-out-str (pprint/pprint info)))
+  (util/dbug* "Aether: %s\n" (with-out-str (pprint/pprint info)))
   (on-transfer info))
 
 (defn ^{:boot/from :technomancy/leiningen} build-url


### PR DESCRIPTION
Addresses slow uploads (and probably downloads) of large files.  See issue boot-clj/boot#565.