### PR TITLE
Handle pom <parent> tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ and `technomancy` for the above explanation.
 - Bump [pomegranate](https://github.com/cemerick/pomegranate) and [dynapath](https://github.com/tobias/dynapath) to `1.0.0`. [#612][612]
 - Digest `java.io.File` instead `String` path of jar at sift-action `:add-jar` method [#678][678]
 - Add warning about improper use of repl :eval option [#666][666]
+- Handle pom <parent> tag [#579][579]
 
 #### Fixed
 
@@ -58,6 +59,7 @@ and `technomancy` for the above explanation.
 [678]: https://github.com/boot-clj/boot/pull/678
 [679]: https://github.com/boot-clj/boot/pull/679
 [666]: https://github.com/boot-clj/boot/pull/666
+[579]: https://github.com/boot-clj/boot/pull/579
 
 ## 2.7.2
 

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ deploy: .deployed
 
 .tested: bin/boot
 	(export BOOT_VERSION=$(version) && export BOOT_EMIT_TARGET=no && cd boot/core && ../../bin/boot -x test)
+	(export BOOT_VERSION=$(version) && export BOOT_EMIT_TARGET=no && cd boot/worker && ../../bin/boot -x test)
 	(cd boot/pod && lein test)
 	date > .tested
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -541,16 +541,17 @@
   classifier to your pom.xml, which translates to adding :classifier to this
   task."
 
-  [p project SYM           sym         "The project id (eg. foo/bar)."
-   v version VER           str         "The project version."
-   d description DESC      str         "The project description."
-   c classifier STR        str         "The project classifier."
-   P packaging STR         str         "The project packaging type, i.e. war, pom"
-   u url URL               str         "The project homepage url."
-   s scm KEY=VAL           {kw str}    "The project scm map (KEY is one of url, tag, connection, developerConnection)."
-   l license NAME:URL      {str str}   "The map {name url} of project licenses."
-   o developers NAME:EMAIL {str str}   "The map {name email} of project developers."
-   D dependencies SYM:VER  [[sym str]] "The project dependencies vector (overrides boot env dependencies)."]
+  [p project SYM           sym           "The project id (eg. foo/bar)."
+   v version VER           str           "The project version."
+   d description DESC      str           "The project description."
+   c classifier STR        str           "The project classifier."
+   P packaging STR         str           "The project packaging type, i.e. war, pom"
+   u url URL               str           "The project homepage url."
+   s scm KEY=VAL           {kw str}      "The project scm map (KEY is one of url, tag, connection, developerConnection)."
+   l license NAME:URL      {str str}     "The map {name url} of project licenses."
+   o developers NAME:EMAIL {str str}     "The map {name email} of project developers."
+   D dependencies SYM:VER  [[sym str]]   "The project dependencies vector (overrides boot env dependencies)."
+   a parent SYM:VER=PATH   [sym str str] "The project dependency vector of the parent project, path included."]
 
   (let [tgt  (core/tmp-dir!)
         tag  (or (:tag scm) (util/guard (git/last-commit)))
@@ -561,7 +562,8 @@
                :dependencies deps
                :developers developers
                :classifier classifier
-               :packaging (or packaging "jar"))]
+               :packaging (or packaging "jar")
+               :parent parent)]
     (when-not (and project version)
       (throw (Exception. "need project and version to create pom.xml")))
     (let [[project version] (pod/canonical-coord [project version])

--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -1,0 +1,28 @@
+(set-env!
+ :source-paths #{"src" "test"}
+ :dependencies '[[net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
+                 [mvxcvi/puget                "1.0.1"]
+                 [reply                       "0.3.7"]
+                 [cheshire                    "5.3.1"]
+                 [clj-jgit                    "0.8.0"]
+                 [clj-yaml                    "0.4.0"]
+                 [javazoom/jlayer             "1.0.1"]
+                 [net.java.dev.jna/jna        "4.1.0"]
+                 [alandipert/desiderata       "1.0.2"]
+                 [org.clojure/data.xml        "0.0.8"]
+                 [org.clojure/data.zip        "0.1.1"]
+                 [org.clojure/tools.namespace "0.2.11"]
+
+                 [metosin/boot-alt-test "0.3.2" :scope "test"]])
+
+(ns-unmap 'boot.user 'test)
+
+(require '[metosin.boot-alt-test :refer [alt-test]])
+
+(import boot.App)
+
+(deftask test []
+  (comp
+   (with-pass-thru [fs]
+     (boot.util/info "Testing against version %s\n" (App/config "BOOT_VERSION")))
+   (alt-test)))

--- a/boot/worker/test/boot/aether_test.clj
+++ b/boot/worker/test/boot/aether_test.clj
@@ -1,7 +1,0 @@
-(ns boot.aether-test
-  (:require [clojure.test :refer :all]
-            [boot.aether :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/boot/worker/test/boot/pom_test.clj
+++ b/boot/worker/test/boot/pom_test.clj
@@ -1,0 +1,42 @@
+(ns boot.pom-test
+  (:require [boot.pom :as pom]
+            [clojure.test :as test :refer [deftest is testing]]
+            [clojure.zip :as zip]
+            [clojure.data.xml :as dxml]
+            [clojure.data.zip.xml :as dzxml]))
+
+(deftest pom-parent
+
+  (testing "pom-xml-parse-string"
+    (let [xml-str "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n                      https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n  <modelVersion>4.0.0</modelVersion>\n \n  <parent>\n    <groupId>org.codehaus.mojo</groupId>\n    <artifactId>my-parent</artifactId>\n    <version>2.0</version>\n    <relativePath>../my-parent</relativePath>\n  </parent>\n \n  <artifactId>my-project</artifactId>\n</project>\n"
+          {:keys [parent]} (pom/pom-xml-parse-string xml-str)]
+      (is (= '[org.codehaus.mojo/my-parent "2.0"] (:dependency parent)) "The parent :dependency must exist and match the example")
+      (is (= "../my-parent" (:relative-path parent)) "The parent :relative-path key must exist and match the example"))
+
+    (let [xml-str "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n                      https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n  <modelVersion>4.0.0</modelVersion>\n \n  <groupId>org.codehaus.mojo</groupId>\n  <artifactId>my-parent</artifactId>\n  <version>2.0</version>\n  <packaging>pom</packaging>\n</project>"
+          {:keys [parent]} (pom/pom-xml-parse-string xml-str)]
+      (is (nil? parent) "The parent tag must not exist if missing in the pom"))
+
+    (let [xml-str "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n                      https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n  <modelVersion>4.0.0</modelVersion>\n \n  <parent>\n    <artifactId>my-parent</artifactId>\n    <version>2.0</version>\n  </parent>\n \n  <artifactId>my-project</artifactId>\n</project>\n"
+          {:keys [parent]} (pom/pom-xml-parse-string xml-str)]
+      (is (= '[my-parent "2.0"] (-> :dependency parent)) "The parent :dependency must exist and be just the artifactId of the example")
+      (is (nil? (-> parent :dependency first namespace)) "The parent :dependency must exist but should not have the groupId as per example")
+      (is (nil? (:relative-path parent)) "The parent :relative-path must be nil as it is not in the example"))
+
+    ;; Edge case - parent tag is there but does not have artifactId
+    (let [xml-str "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n  xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0\n                      https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n  <modelVersion>4.0.0</modelVersion>\n \n  <parent>\n    <groupId>org.codehaus.mojo</groupId>\n    </parent>\n \n  <artifactId>my-project</artifactId>\n</project>\n"
+          {:keys [parent]} (pom/pom-xml-parse-string xml-str)]
+      (is (nil? (-> :dependency parent)) "The parent :dependency should be nil if no artifactId is there")))
+
+  (testing "pom-xml :parent"
+    (let [parent-loc (-> {:project 'group/my-plugin
+                          :version "1.2.0"
+                          :parent '[org.codehaus.mojo/my-parent "2.0"]}
+                         pom/pom-xml
+                         pr-str
+                         dxml/parse-str
+                         zip/xml-zip
+                         (dzxml/xml1-> :parent))]
+      (is (not (nil? (dzxml/xml1-> parent-loc :groupId "org.codehaus.mojo"))) "I should contain a :groupId tag with correct content")
+      (is (not (nil? (dzxml/xml1-> parent-loc :artifactId "my-parent"))) "It should contain a :artifactId tag with correct content")
+      (is (not (nil? (dzxml/xml1-> parent-loc :version "2.0"))) "It should contain a :version tag with correct content"))))


### PR DESCRIPTION
 * adds support for the `<parent>` tag in `boot.pom` for both writing and reading `pom.xml` files.
* also removes some obsolete file and hooks up boot/worker tests in Makefile.