### PR TITLE
New task: bare-repl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ ensure that message ends in a newline.
 ##### Tasks
 
 - Added the `socket-server` task for starting a [Clojure 1.8.0+ socket server](https://clojure.org/reference/repl_and_main#_launching_a_socket_server). [#549][549]
+- Added the `bare-repl` task for starting a simple interactive REPL session (a la [clojure.main/repl](https://clojure.org/reference/repl_and_main#_launching_a_repl)) without launching a nREPL server. [#582][582]
 
 #### API Functions
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -483,6 +483,21 @@
           (core/with-post-wrap [_]
             (when (or client (not server)) @repl-cli)))))
 
+(core/deftask bare-repl
+  "Start a bare REPL session for the current project.
+
+   Compared to the repl task, the bare-repl task starts up more quickly but
+   lacks features such as nREPL connectivity and colored stacktraces.
+
+   Use the rlwrap Unix tool to add readline functionality:
+
+   # rlwrap boot bare-repl"
+  [e eval EXPR      edn   "The form the client will evaluate in the boot.user ns."
+   i init PATH      str   "The file to evaluate in the boot.user ns."
+   n init-ns NS     sym   "The initial REPL namespace."]
+  (core/with-pass-thru [_]
+    (repl/launch-bare-repl *opts*)))
+
 (core/deftask socket-server
   "Start a socket server.
 

--- a/boot/pod/src/boot/repl.clj
+++ b/boot/pod/src/boot/repl.clj
@@ -59,6 +59,21 @@
   (let [opts (->> options setup-nrepl-env!)]
     (@start-server opts)))
 
+(defn launch-bare-repl
+  [{to-eval :eval,
+    :keys [init init-ns]
+    :or {init-ns 'boot.user}}]
+  (require 'clojure.main 'clojure.repl)
+  ((resolve 'clojure.main/repl)
+   :init (fn []
+           (when init
+             (load-file init))
+           (when to-eval
+             (eval to-eval))
+           (in-ns init-ns)
+           (when (= 'boot.user init-ns)
+             (refer 'clojure.repl)))))
+
 (defn launch-socket-server
   "See #boot.task.built-in/socket-server for explanation of options."
   [{:keys [bind port accept]}]


### PR DESCRIPTION
This PR adds a new bare-repl task to start a "bare" or terminal repl, as per clojure.main/repl.

A bare repl has a few advantages over the nREPL-based `boot repl` setup:

- fewer moving parts (no pods, no network connection)
- much faster startup
- direct access to tty, i.e. this works with `boot repl -B` but not with `boot repl`: ```(.readPassword (System/console) "Password: " (object-array []))```

Like the normal `repl` task when not invoked with the `-s` option, `boot bare-repl` blocks the boot pipeline until the repl is closed with `^D`.

Essentially the bare REPL is closer to what you get when following Clojure's [Getting Started guide](https://clojure.org/reference/repl_and_main). Disadvantages of `boot bare-repl` compared to `boot repl` include:

- no pretty exceptions
- no readline support (but `rlwrap boot repl -B` works well)