### PR TITLE
Explicitly bind *print-level* and *print-length* to nil

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -865,12 +865,14 @@
   value of that key and the result will become the new value (similar to how
   clojure.core/update-in works."
   [& kvs]
-  (doseq [[k v] (order-set-env-keys (partition 2 kvs))]
-    (let [v'  (if-not (fn? v) v (v (get-env k)))
-          v'' (if-let [b (get @cli-base k)] (merge-if-coll b v') v')]
-      (assert (printable-readable? v'')
-              (format "value not readable by Clojure reader\n%s => %s" (pr-str k) (pr-str v'')))
-      (swap! boot-env update-in [k] (partial pre-env! k) v'' @boot-env))))
+  (binding [*print-level* nil
+            *print-length* nil]
+    (doseq [[k v] (order-set-env-keys (partition 2 kvs))]
+      (let [v'  (if-not (fn? v) v (v (get-env k)))
+            v'' (if-let [b (get @cli-base k)] (merge-if-coll b v') v')]
+        (assert (printable-readable? v'')
+                (format "value not readable by Clojure reader\n%s => %s" (pr-str k) (pr-str v'')))
+        (swap! boot-env update-in [k] (partial pre-env! k) v'' @boot-env)))))
 
 (defn merge-env!
   "Merges the new values into the current values for the given keys in the env


### PR DESCRIPTION
This should prevent user setting of these values for reasonable use in the REPL from preventing `set-env!` from failing the `printable-readable?` round-trip test.

Fixes #586.