### PR TITLE
New task: call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ ensure that message ends in a newline.
 ##### Tasks
 
 - Added the `socket-server` task for starting a [Clojure 1.8.0+ socket server](https://clojure.org/reference/repl_and_main#_launching_a_socket_server). [#549][549]
+- Added the `call` task to execute arbitrary code as part of the pipeline, either via an existing function symbol or by providing a form. Similar to [lein run](https://github.com/technomancy/leiningen#basic-usage), `call` can be used, for example, to start a [component system](https://github.com/stuartsierra/component).
 
 #### API Functions
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -1024,3 +1024,42 @@
                 (util/info "Tag %s already created for %s\n" tag commit)
                 (do (util/info "Creating tag %s...\n" v)
                     (git/tag v "release"))))))))))
+
+(core/deftask call
+  "Call a function or evaluate a piece of code
+
+Multiple functions or forms can be specified. For namespaced functions, the
+namespace is automatically required. Execution occurs before tasks appearing
+later in the pipeline (or after the tasks, if --post is specified)."
+  [f function SYMBOL [sym] "Functions to execute"
+   e eval     FORM   [edn] "Forms to execute"
+   p print           bool  "Print results to *out*"
+   P post            bool  "Execute after rather than before subsequent tasks"
+   o once            bool  "Run only once if used with watch"]
+  (let [called? (atom false)
+        run (fn []
+              (when (or (not once) (not @called?))
+                (doseq [ns (->> function
+                                (map #(some-> % namespace symbol))
+                                (remove nil?)
+                                set)]
+                  (require ns))
+                (doseq [sym function]
+                  (if-let [f (resolve sym)]
+                    (do
+                      (util/dbug "Invoking %s...\n" sym)
+                      (cond-> (f)
+                        print println))
+                    (throw (RuntimeException. (str "Could not resolve symbol " sym)))))
+                (doseq [form eval]
+                  (util/dbug "Evaluating %s...\n" (pr-str form))
+                  (cond-> (clojure.core/eval form)
+                    print println))
+                (reset! called? true)))]
+    (if post
+      (core/with-post-wrap [fileset]
+        (run)
+        fileset)
+      (core/with-pre-wrap [fileset]
+        (run)
+        fileset))))


### PR DESCRIPTION
This task can be used for ad-hoc code, either from the command line or
from build.boot. Use cases:

- run the project's entry point, like `lein run`
- experiments from the CLI: `boot call --print -f clojure-version`
- start a web server: `boot watch cljs call --once -f my.project/start`

As used from build.boot, the call task has the advantage that new users
don't need to learn about with-pass-thru to execute project code.

The `--eval` option allows to execute an arbitrary Clojure from. It is
similar to boot's `--init` but can be run as part of a boot pipeline.