### PR TITLE
feat: implement visitFileFailed for mkvisitor

### DIFF
--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -100,7 +100,11 @@
                    (add-blob! blob path i link)
                    (swap! tree assoc p (map->TmpFile (assoc m :path p :id i :hash h :time t))))
                  (catch java.nio.file.NoSuchFileException _
-                   (util/dbug* "Tmpdir: file not found: %s\n" (.toString p))))) )))))
+                   (util/dbug* "Tmpdir: file not found: %s\n" (.toString p)))))))
+      (visitFileFailed [^Path path ^java.io.IOException e]
+        (with-let [_ fs/skip-subtree]
+          (let [p (str (.relativize root path))]
+            (util/dbug* "Tmpdir: failed to visit: %s\n" (.toString p))))))))
 
 (defn- dir->tree!
   [^File dir ^File blob]
@@ -263,7 +267,7 @@
                              err? (fatal-conflict? dst)
                              this (or (and (not err?) this)
                                       (update-in this [:tree] dissoc p))]
-                         (if err? 
+                         (if err?
                            (util/warn "Merge conflict: not adding %s\n" p)
                            (do (util/trace* "Commit: adding   %s %s...\n" (id tmpf) p)
                                (file/hard-link src dst)))


### PR DESCRIPTION
Reason:
[This project](https://github.com/degree9/boot-semver/blob/master/src/degree9/boot_semver.clj#L152) does a treewalk on our project structure, which contains folders/files that cannot be opened by the boot process, this causes the process to exit.
This PR fixes this issue by ignoring these files/directories.