### PR TITLE
Fixes issue #555

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - `set-env!` works even if the user has set `*print-level*` or `*print-length*` to non-nil in their `$BOOT_HOME/profile.boot`. [#587][587] [#586][586]
 - `tmpfile` "Commit: adding..." messages now only appear with `-vv` which eases debugging tasks with `-v` [#557][557]
 - Pod tests pass and can be run with `make` [#567][567]
+- `file-filter` (called by all `by-*` functions) throws an error if no criteria are specified.
 
 #### Fixed
 

--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -1218,6 +1218,7 @@
   "A file filtering function factory. FIXME: more documenting here."
   [mkpred]
   (fn [criteria files & [negate?]]
+    (assert (seq criteria) "boot.core/file-filter requires a list of criteria but nil was passed in, make sure your `by-*` calls are passing them.")
     (let [tmp?   (partial satisfies? tmpd/ITmpFile)
           ->file #(if (tmp? %) (io/file (tmp-path %)) (io/file %))
           pred (apply juxt (mapv mkpred criteria))]


### PR DESCRIPTION
This fixes issue #555

This modifies the file-filter function so that if the criteria seq is
empty, it simply returns an empty list. 

An empty list was chosen instead of simply returning nil because an empty list allows seq functions (`conj`, `cons`, etc.) to continue to work.