### PR TITLE
[Fix] Tmpdir Symbolic Links

### DIFF
--- a/boot/pod/src/boot/tmpdir.clj
+++ b/boot/pod/src/boot/tmpdir.clj
@@ -102,7 +102,7 @@
                    (add-blob! blob path i link)
                    (swap! tree assoc p (map->TmpFile (assoc m :path p :id i :hash h :time t))))
                  (catch java.nio.file.NoSuchFileException _
-                   (util/dbug* "Tmpdir: file not found: %s\n" (.toString p)))))))
+                   (util/dbug* "Tmpdir: file not found: %s\n" (.toString p))))))))
       (visitFileFailed [^Path path ^java.io.IOException e]
         (with-let [_ fs/skip-subtree]
           (util/dbug* "Tmpdir: failed to visit: %s\n" (str (.relativize root path))))))))


### PR DESCRIPTION
This patch allows adding tmpdir folders which contain symbolic links. Symbolic links are visited by the file visitor, visitfile now checks if file is a symbolic link.