### PR TITLE
Bump pomegranate and dynapath to 1.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,36 @@
 
 ## master
 
+#### Breaking
+
+If you happen to receive "Tried to use insecure HTTP repository without TLS",
+it means your project was configured to download dependencies from a repository
+that does not use TLS encryption.
+This is NOT suppored anymore because it exposes you to trivially-executed
+man-in-the-middle attacks.
+In the rare event that you don't care about the security of the machines
+running your project, you can enable support for unprotected repositories by
+explicitely set a custom `wagon-factory`:
+
+    ;; never do this
+    (require 'cemerick.pomegranate.aether)
+    (cemerick.pomegranate.aether/register-wagon-factory!
+     "http "#(org.apache.maven.wagon.providers.http.HttpWagon.))
+
+It's also possible you have a dependency which includes a reference to an
+insecure repository for retrieving its own dependencies. If this happens it is
+strongly recommended to add an `:exclusion` and report a bug with the
+dependency which does this.
+
+Kudos to the folks working on
+[the related `pomegranate` PR](https://github.com/cemerick/pomegranate/pull/83)
+and `technomancy` for the above explanation.
+
 #### Improved
 
 - Boot is officially Maven Central compatible. Make sure the `sources` and `javadoc` artifacts are on the fileset and `:classifier` is correctly set.
 - Environment variables BOOT_AS_ROOT, BOOT_WATCHERS_DISABLE und BOOT_COLOR accept `true` as a truthy value beside `1` and `yes` [#631][631]
+- Bump [pomegranate](https://github.com/cemerick/pomegranate) and [dynapath][https://github.com/tobias/dynapath] to `1.0.0`. [#612][612]
 
 #### Fixed
 
@@ -20,6 +46,7 @@
 [654]: https://github.com/boot-clj/boot/issues/654
 [566]: https://github.com/boot-clj/boot/pull/566
 [631]: https://github.com/boot-clj/boot/issues/631
+[612]: https://github.com/boot-clj/boot/pull/612
 
 ## 2.7.2
 

--- a/boot/aether/project.clj
+++ b/boot/aether/project.clj
@@ -16,5 +16,6 @@
   :dependencies [[org.clojure/clojure               "1.6.0"  :scope "compile"]
                  [boot/base                         ~version :scope "provided"]
                  [boot/pod                          ~version :scope "compile"]
-                 [com.cemerick/pomegranate          "0.3.1"  :scope "compile"]
-                 [org.apache.maven.wagon/wagon-http "2.9"    :scope "compile"]])
+                 [com.cemerick/pomegranate          "1.0.0"  :scope "compile"]
+                 [org.apache.maven.wagon/wagon-http "2.12"   :scope "compile"
+                  :exclusions [org.apache.maven.wagon/wagon-provider-api]]])

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -14,8 +14,8 @@
     [java.io File]
     [java.util.jar JarFile]
     [java.util.regex Pattern]
-    [org.sonatype.aether.resolution DependencyResolutionException]
-    [org.sonatype.aether.transfer MetadataNotFoundException ArtifactNotFoundException]))
+    [org.eclipse.aether.resolution DependencyResolutionException]
+    [org.eclipse.aether.transfer MetadataNotFoundException ArtifactNotFoundException]))
 
 (def offline?             (atom false))
 (def update?              (atom :daily))

--- a/boot/base/pom.in.xml
+++ b/boot/base/pom.in.xml
@@ -24,11 +24,11 @@
   <repositories>
     <repository>
       <id>sonatype</id>
-      <url>http://oss.sonatype.org/content/repositories/releases/</url>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
     </repository>
     <repository>
       <id>sonatype-snaps</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
     <repository>
       <id>clojars</id>

--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -17,5 +17,5 @@
                    :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies   [[boot/base                               ~version :scope "provided"]
                    [org.clojure/clojure                     "1.6.0"  :scope "provided"]
-                   [org.tcrawley/dynapath                   "0.2.5"  :scope "compile"]
+                   [org.tcrawley/dynapath                   "1.0.0"  :scope "compile"]
                    [org.projectodd.shimdandy/shimdandy-impl "1.2.0"  :scope "compile"]])

--- a/boot/pod/project.clj
+++ b/boot/pod/project.clj
@@ -11,8 +11,8 @@
   :url            "http://github.com/boot-clj/boot"
   :scm            {:url "https://github.com/boot-clj/boot.git" :dir "../../"}
   :repositories   [["clojars"        {:url "https://clojars.org/repo" :creds :gpg :sign-releases false}]
-                   ["sonatype"       {:url "http://oss.sonatype.org/content/repositories/releases"}]
-                   ["sonatype-snaps" {:url "http://oss.sonatype.org/content/repositories/snapshots"}]]
+                   ["sonatype"       {:url "https://oss.sonatype.org/content/repositories/releases"}]
+                   ["sonatype-snaps" {:url "https://oss.sonatype.org/content/repositories/snapshots"}]]
   :license        {:name "Eclipse Public License"
                    :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies   [[boot/base                               ~version :scope "provided"]


### PR DESCRIPTION
Hello folks!

Now that https://github.com/cemerick/pomegranate/pull/83 is in, I took the time to adapt to `0.4.0-alpha1`. Leiningen is testing the change too and it makes sense to keep in sync.

One notable change is:

> Note that item 3 above is technically a breaking change; however I would argue it is a bugfix for a critical security flaw. It's still possible to explicitly opt-in to non-TLS HTTP repositories if you don't care for security by calling register-wagon-factory! yourself.

I wanted to write it down here so that we don't miss it.

I am going to try it locally of course and report if I find any issue with it.