### PR TITLE
Fix #547 - Concatenate strings and load the result, rather than reading each separately

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ escape `%` in message to prevent errors about bad string formatting, and
 ensure that message ends in a newline.
 - Artifact upload slow because of an expensive evaluation of a debugging arguments for all calls to `transfer-listener` [#565][565] [#558][558]
 - With-cp does not consider source/resource paths
+- Evaluation of boot script is now done via string concatenation and `load-string`, rather than `read-string` [#571][571]
 
 ##### Tasks
 


### PR DESCRIPTION
I've verified that @alexander-yakushev's example correctly fails because of the unmatched delimiter, as well as verifying that aliased namespaced keywords work correctly.