### PR TITLE
Use classifier when deploying artifacts

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -342,11 +342,11 @@
      (deploy env repo jarpath nil pom-or-artifacts)
      (deploy env repo jarpath pom-or-artifacts nil)))
   ([env [repo-id repo-settings] jarpath pompath artifact-map]
-   (let [pom-str                           (pod/pom-xml jarpath pompath)
-         {:keys [project version] :as pom} (pom-xml-parse-string pom-str)
-         pomfile                           (pom-xml-tmp pom-str)]
+   (let [pom-str                                      (pod/pom-xml jarpath pompath)
+         {:keys [project version classifier] :as pom} (pom-xml-parse-string pom-str)
+         pomfile                                      (pom-xml-tmp pom-str)]
      (aether/deploy
-       :coordinates  [project version]
+       :coordinates  [project version :classifier classifier]
        :pom-file     (io/file pomfile)
        :artifact-map (jarpath-on-artifact-map artifact-map pom jarpath)
        :transfer-listener transfer-listener

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -1001,6 +1001,7 @@
                                (util/info "Signing %s...\n" (.getName f))
                                (gpg/sign-jar tgt f pom {:gpg-key gpg-user-id
                                                         :gpg-passphrase gpg-passphrase}))]
+            (util/debug* "Signed artifact-map %s\n" artifact-map)
             (assert (or (not ensure-branch) (= b ensure-branch))
                     (format "current git branch is %s but must be %s" b ensure-branch))
             (assert (or (not ensure-clean) clean?)

--- a/boot/pod/src/boot/gpg.clj
+++ b/boot/pod/src/boot/gpg.clj
@@ -50,7 +50,7 @@
     (str file ".asc")))
 
 (defn sign-jar
-  [outdir jarfile pompath opts]
+  [outdir jarfile pompath gpg-options]
   (shell/with-sh-dir
     outdir
     (let [jarname (.getName jarfile)
@@ -59,7 +59,7 @@
                     (.deleteOnExit)
                     (spit (pod/pom-xml jarfile pompath)))
           pomout  (io/file outdir (.replaceAll jarname "\\.jar$" ".pom.asc"))
-          sign-it #(slurp (sign (.getPath %) opts))]
+          sign-it #(slurp (sign (.getPath %) gpg-options))]
       (spit pomout (sign-it pomfile))
       (spit jarout (sign-it jarfile))
       {[:extension "jar.asc"] (.getPath jarout)


### PR DESCRIPTION
This patch fixes bug #623.

This also refactors the code so that if a classifier is found in the artifact definition, we don't sign the pom. The pom is signed only for the main .jar artifact.

Now with `:classifier` set correctly to either `javadoc` and `sources`, we can deploy signed artifact for Maven Central/Sonatype. Before, the artifacts were rejected by their automated "quality assurance" system.
