### PR TITLE
Include classifier when deploying artifacts, fixes #623

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,18 @@
 
 ## master
 
+#### Improved
+
+- Boot is officially Maven Central compatible. Make sure the `sources` and `javadoc` artifacts are on the fileset and `:classifier` is correctly set.
+
 #### Fixed
 
 - When directories or files cannot be opened by boot, don't fail but log something in debug level [#598][598] & [#629][629]
 - `fileset-diff` correctly handles nested data structures [#566][566]
+- Boot does not sign jars with classifiers [#625][625]
 
 [598]: https://github.com/boot-clj/boot/pull/598
+[625]: https://github.com/boot-clj/boot/pull/625
 [629]: https://github.com/boot-clj/boot/pull/629
 
 ## 2.7.2

--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -335,23 +335,20 @@
        :local-repo   (or (:local-repo env) @local-repo nil)))))
 
 (defn deploy
-  ([env repo jarpath]
-   (deploy env repo jarpath nil))
-  ([env repo jarpath pom-or-artifacts]
-   (if (map? pom-or-artifacts)
-     (deploy env repo jarpath nil pom-or-artifacts)
-     (deploy env repo jarpath pom-or-artifacts nil)))
-  ([env [repo-id repo-settings] jarpath pompath artifact-map]
-   (let [pom-str                           (pod/pom-xml jarpath pompath)
-         {:keys [project version] :as pom} (pom-xml-parse-string pom-str)
-         pomfile                           (pom-xml-tmp pom-str)]
-     (aether/deploy
-       :coordinates  [project version]
-       :pom-file     (io/file pomfile)
-       :artifact-map (jarpath-on-artifact-map artifact-map pom jarpath)
-       :transfer-listener transfer-listener
-       :repository   {repo-id repo-settings}
-       :local-repo   (or (:local-repo env) @local-repo nil)))))
+  "Deploy a jar file.
+
+  The pom always needs to be passed along and valid, if artifact map is "
+  [env [repo-id repo-settings] jarpath pompath artifact-map]
+  (let [pom-str                                      (pod/pom-xml jarpath pompath)
+        {:keys [project version classifier] :as pom} (pom-xml-parse-string pom-str)
+        pomfile                                      (pom-xml-tmp pom-str)]
+    (aether/deploy
+     :coordinates  [project version :classifier classifier]
+     :pom-file     (when-not classifier (io/file pomfile))
+     :artifact-map (jarpath-on-artifact-map artifact-map pom jarpath)
+     :transfer-listener transfer-listener
+     :repository   {repo-id repo-settings}
+     :local-repo   (or (:local-repo env) @local-repo nil))))
 
 (def ^:private wagon-files (atom #{}))
 

--- a/boot/pod/src/boot/gpg.clj
+++ b/boot/pod/src/boot/gpg.clj
@@ -49,8 +49,15 @@
                       "authorship of your jar, don't set :gpg-sign option of push task to true.\n")))
     (str file ".asc")))
 
-(defn sign-jar
-  "Sign a jar.
+(defn sign-it
+  "Sign a java.io.File given the options."
+  [f gpg-options]
+  (slurp (sign (.getPath f) gpg-options)))
+
+(defn sign-pom
+  "Materialize and sign the pom contained in jarfile.
+  Returns an artifact-map entry - a map from partial coordinates to file
+  path or File (see pomegranate/aether.clj for details).
 
   If you receive a \"Could not sign ... gpg: no default secret key: secret key
   not available\" error, make sure boot is using the right gpg executable.  You
@@ -60,21 +67,40 @@
 
     BOOT_GPG_COMMAND=gpg2 boot push --gpg-sign ...
 
-  You rarely need to use this directly."
-  [outdir jarfile pompath opts]
+  You rarely need to use this directly, use the push task instead."
+  [outdir jarfile pompath gpg-options]
   (shell/with-sh-dir
     outdir
     (let [jarname (.getName jarfile)
-          jarout  (io/file outdir (str jarname ".asc"))
           pomfile (doto (File/createTempFile "pom" ".xml")
                     (.deleteOnExit)
                     (spit (pod/pom-xml jarfile pompath)))
-          pomout  (io/file outdir (.replaceAll jarname "\\.jar$" ".pom.asc"))
-          sign-it #(slurp (sign (.getPath %) opts))]
-      (spit pomout (sign-it pomfile))
-      (spit jarout (sign-it jarfile))
-      {[:extension "jar.asc"] (.getPath jarout)
-       [:extension "pom.asc"] (.getPath pomout)})))
+          pomout  (io/file outdir (.replaceAll jarname "\\.jar$" ".pom.asc")) ]
+      (spit pomout (sign-it pomfile gpg-options))
+      [[:extension "pom.asc"] (.getPath pomout)])))
+
+(defn sign-jar
+  "Sign a jar.
+
+  Returns an artifact-map entry - a map from partial coordinates to file
+  path or File (see pomegranate/aether.clj for details).
+
+  If you receive a \"Could not sign ... gpg: no default secret key: secret key
+  not available\" error, make sure boot is using the right gpg executable.  You
+  can use the BOOT_GPG_COMMAND environment variable for that.
+
+  In order to use gpg2, for instance, run:
+
+    BOOT_GPG_COMMAND=gpg2 boot push --gpg-sign ...
+
+  You rarely need to use this directly, use the push task instead."
+  [outdir jarfile gpg-options]
+  (shell/with-sh-dir
+    outdir
+    (let [jarname (.getName jarfile)
+          jarout  (io/file outdir (str jarname ".asc"))]
+      (spit jarout (sign-it jarfile gpg-options))
+      [[:extension "jar.asc"] (.getPath jarout)])))
 
 (defn decrypt
   "Use gpg to decrypt a file -- returns string contents of file."


### PR DESCRIPTION
This patch fixes bug #623.

This also refactors the code so that if a classifier is found in the artifact definition, we don't sign the pom. The pom is signed only for the main .jar artifact.

With `:classifier` correctly set to either `javadoc` and `sources`, we can deploy signed artifact for Maven Central/Sonatype. Before, the artifacts were rejected by their automated "quality assurance" system.

The necessary steps for adding `sources` and `javadoc` are just a few. Specifically, you need to use the `jar` task with `:file` options and append `:classifier` to the `pom` task:

    (comp
       ...
        (pom :classifier "sources")
        (jar :project 'group-id/project-name
               :file (str/join "-" [artifact-name artifact-version "sources.jar"]))
       ...)