### PR TITLE
Improves error message when user tries to create multi-arity tasks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 - `set-env!` works even if the user has set `*print-level*` or `*print-length*` to non-nil in their `$BOOT_HOME/profile.boot`. [#587][587] [#586][586]
 - `tmpfile` "Commit: adding..." messages now only appear with `-vv` which eases debugging tasks with `-v` [#557][557]
 - Pod tests pass and can be run with `make` [#567][567]
+- Improved error message when a user tries to use a multi-arity format for
+  tasks.
 
 #### Fixed
 

--- a/boot/core/src/boot/cli.clj
+++ b/boot/core/src/boot/cli.clj
@@ -246,6 +246,12 @@
            (with-meta ~varmeta)))))
 
 (defmacro defclifn [sym & forms]
+  (let [no-doc-string-forms (if (string? (first forms))
+                              (rest forms)
+                              forms)]
+    (if (and (list? (first no-doc-string-forms))
+             (vector? (first (first no-doc-string-forms))))
+      (throw (IllegalArgumentException. "Multiple arity format not supported for tasks. Use single arity format. Ex (deftask build [x y ...] ;commands)"))))
   `(let [var#    (def ~sym (clifn ~@forms))
          fmtdoc# (comp string/trim (#'indent 2))
          meta#   (update-in (meta ~sym) [:doc] fmtdoc#)]


### PR DESCRIPTION
Fixes issue #574.

When a user tries to use a mult-arity format for deftask, it now throws an `IllegalArgumentException` with the error message: "Multiple arity format not supported for tasks. Use single arity format. Ex (deftask build [x y ...] ;commands)"