### PR TITLE
Fix typo in socket-server docstring

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -520,7 +520,7 @@
 
   The REPL can be accessed with the command
 
-     $ nc localhost $(cat .server-port)"
+     $ nc localhost $(cat .socket-port)"
 
   [b bind ADDR      str    "The address server listens on."
    p port PORT      int    "The port to listen to."


### PR DESCRIPTION
Incorrectly said the file was `.server-port` in the example `nc` command.