### PR TITLE
Accept true as truthy value in environment vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 #### Improved
 
 - Boot is officially Maven Central compatible. Make sure the `sources` and `javadoc` artifacts are on the fileset and `:classifier` is correctly set.
+- Environment variables BOOT_AS_ROOT, BOOT_WATCHERS_DISABLE und BOOT_COLOR accept `true` as a truthy value beside `1` and `yes` [#631][631]
 
 #### Fixed
 
@@ -15,6 +16,7 @@
 [598]: https://github.com/boot-clj/boot/pull/598
 [625]: https://github.com/boot-clj/boot/pull/625
 [629]: https://github.com/boot-clj/boot/pull/629
+[631]: https://github.com/boot-clj/boot/issues/631
 
 ## 2.7.2
 

--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -433,8 +433,9 @@ public class App {
 
     public static void
     main(String[] args) throws Exception {
+        String asroot = config("BOOT_AS_ROOT", "no");
         if (System.getProperty("user.name").equals("root")
-                && ! config("BOOT_AS_ROOT", "no").equals("yes"))
+            && ! (asroot.equals("yes") || asroot.equals("1") || asroot.equals("true")))
             throw new Exception("refusing to run as root (set BOOT_AS_ROOT=yes to force)");
 
         // BOOT_VERSION is decided by the loader; it will respect the

--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -22,13 +22,13 @@
   system. Constrained environments like clould build containers limit
   the number of inotify handles, and watchers are only necessary for
   interactive dev, not one-shot jobs.  environment variable or
-  configuration option BOOT_WATCHERS_DISABLE to either '1' or 'yes' to
-  disable inotify; any other value keeps normal behavior."
+  configuration option BOOT_WATCHERS_DISABLE to either '1' or 'yes' or
+  'true' to disable inotify; any other value keeps normal behavior."
   []
   (let [value (boot.App/config "BOOT_WATCHERS_DISABLE")]
     (if (string/blank? value)
       true
-      (not (#{"1" "yes"}
+      (not (#{"1" "yes" "true"}
             (string/lower-case value))))))
 
 (defn colorize?-system-default
@@ -37,12 +37,12 @@
   output is disabled on Windows by default, but enabled by default
   on other platforms. The default can be overriden by setting the
   environment variable or configuration option BOOT_COLOR to
-  either '1' or 'yes' to enable it; any other value disables
+  either '1' or 'yes' or 'true' to enable it; any other value disables
   colorization."
   []
   (let [value (boot.App/config "BOOT_COLOR")]
     (if-not (string/blank? value)
-      (#{"1" "yes"} (string/lower-case value))
+      (#{"1" "yes" "true"} (string/lower-case value))
       (not (boot.App/isWindows)))))
 
 (def ^:dynamic *verbosity*

--- a/doc/boot.util.md
+++ b/doc/boot.util.md
@@ -105,8 +105,8 @@ Return whether we should colorize output on this system. This is
 true, unless we're on Windows, where this is false. The default
 console on Windows does not interprete ansi escape codes. The
 default can be overriden by setting the environment variable
-BOOT_COLOR=1 or BOOT_COLOR=yes to turn it on or any other value to
-turn it off.
+BOOT_COLOR=1 or BOOT_COLOR=yes or BOOT_COLOR=true to turn it on
+or any other value to turn it off.
 ```
 
 <hr>


### PR DESCRIPTION
BOOT_AS_ROOT, BOOT_DISABLE_WATCHERS and BOOT_COLOR environment variables
allow true as a truthy value beside 1 and yes. Fixes #631.