### PR TITLE
Ensure :boot.util/omit-stacktrace? preserved

### DIFF
--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -219,4 +219,4 @@
                        c (.getCause cx)
                        m (.getMessage (or c cx))
                        x (or c cx)]
-                   (throw (ex-info m (sorted-map :line l) x))))))))))
+                   (throw (ex-info m (merge (sorted-map :line l) (ex-data c) x))))))))))

--- a/boot/core/src/boot/main.clj
+++ b/boot/core/src/boot/main.clj
@@ -219,4 +219,4 @@
                        c (.getCause cx)
                        m (.getMessage (or c cx))
                        x (or c cx)]
-                   (throw (ex-info m (merge (sorted-map :line l) (ex-data c) x))))))))))
+                   (throw (ex-info m (merge (sorted-map :line l) (ex-data c)) x))))))))))


### PR DESCRIPTION
This ensures any ex-info data is preserved across the new exception containing `:line`. In particular, this will propagate `:boot.util/omit-stacktrace?`