### PR TITLE
Display ex-info data when omitting stacktrace

### DIFF
--- a/boot/pod/src/boot/util.clj
+++ b/boot/pod/src/boot/util.clj
@@ -328,7 +328,13 @@
   [ex]
   (cond
     (= 0 @*verbosity*) nil
-    (::omit-stacktrace? (ex-data ex)) (fail (-> (.getMessage ex) escape-format-string ensure-ends-in-newline))
+    (::omit-stacktrace? (ex-data ex)) 
+    (fail (-> (.getMessage ex) 
+              (str (let [info (dissoc (ex-data ex) ::omit-stacktrace?)]
+                     (when (seq (dissoc info :line))
+                       (str "\n" (with-out-str (clojure.pprint/pprint info))))))
+              escape-format-string 
+              ensure-ends-in-newline))
     (= 1 @*verbosity*) (pretty/write-exception *err* ex nil)
     (= 2 @*verbosity*) (pretty/write-exception *err* ex {:filter nil})
     :else (binding [*out* *err*] (.printStackTrace ex))))


### PR DESCRIPTION
If you throw with `:boot.util/omit-stacktrace?`, you only get the message displayed -- you lose any other data in the exception.

This change will show the `ex-info` data (without `:boot.util/omit-stacktrace?`) if anything beyond `:line` was present. `:line` is injected by `boot.main` and can be suppressed if no other data was added by the user.