### PR TITLE
Allow clojure source jars onto the classpath (#654)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,12 @@
 - When directories or files cannot be opened by boot, don't fail but log something in debug level [#598][598] & [#629][629]
 - `fileset-diff` correctly handles nested data structures [#566][566]
 - Boot does not sign jars with classifiers [#625][625]
+- Allow clojure source jar onto the classpath [#654][654]
 
 [598]: https://github.com/boot-clj/boot/pull/598
 [625]: https://github.com/boot-clj/boot/pull/625
 [629]: https://github.com/boot-clj/boot/pull/629
+[654]: https://github.com/boot-clj/boot/issues/654
 
 ## 2.7.2
 

--- a/boot/pod/src/boot/pod.clj
+++ b/boot/pod/src/boot/pod.clj
@@ -593,7 +593,8 @@
   (let [clj-dep (symbol (boot.App/config "BOOT_CLOJURE_NAME"))
         rm-clj  (if-not ignore-clj?
                   identity
-                  (partial remove #(= clj-dep (first (:dep %)))))]
+                  (partial remove #(and (= clj-dep (first (:dep %)))
+                                        (not-any? #{[:classifier "sources"]} (partition 2 (:dep %))))))]
     (->> env resolve-dependencies rm-clj (map (comp io/file :jar)))))
 
 (defn resolve-nontransitive-dependencies


### PR DESCRIPTION
The rm-clj filter of boot.pod/resolve-dependency-jars prevents adding the
org.clojure/clojure dependency to work around an old issue (see 61c948f),
but was also keeping clojure source artifacts off the classpath.
This change narrows the filter to remove only clojure dependencies that aren't
sources, so one can add e.g.
[org.clojure/clojure "1.9.0-beta2" :classifier "sources"]
to enable jumping to clojure java sources in CIDER.