### PR TITLE
Use bootignore patterns in watcher workers

### DIFF
--- a/boot/core/src/boot/core.clj
+++ b/boot/core/src/boot/core.clj
@@ -741,7 +741,8 @@
         (let [q       (LinkedBlockingQueue.)
               watcher (apply file/watcher! :time dirs)
               paths   (into-array String dirs)
-              k       (pod/with-invoke-worker (boot.watcher/make-watcher q paths))]
+              k       (pod/with-invoke-worker
+                        (boot.watcher/make-watcher q paths :ignore @bootignore))]
           (daemon
             (loop [ret (util/guard [(.take q)])]
               (when ret


### PR DESCRIPTION
Boot uses the ignore patterns parsed from `.bootignore` when syncing src and resource directories, but not in the underlying watch processes. This PR offers a start to solving this discrepancy.

It is also a potential solution for people have node-modules / figwheel builds et ceterae in resource directories experiencing FSEvent dropouts on Mac OSX (eg: https://github.com/boot-clj/boot/issues/641) and improves performance in those cases - but mainly feels consistent.

**note** This won't exclude any added files after the watcher started, since the watchservices take dirs and don't have ignore options. It seems like that could be fixed in `boot.file/watcher!`. This also won't extend the `watch` task yet. It only will filter out .bootignore matches at register time when boot boots.

**disclaimer** I didn't test the entire build since `make install` fails with a TLS error. I just did not want to spend time debugging the build tool for debugging the build tool I was debugging. I did however test the adapted functions in a repl.