### PR TITLE
add a warning when the repl tasks :eval option is passed a string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ and `technomancy` for the above explanation.
 - Environment variables BOOT_AS_ROOT, BOOT_WATCHERS_DISABLE und BOOT_COLOR accept `true` as a truthy value beside `1` and `yes` [#631][631]
 - Bump [pomegranate](https://github.com/cemerick/pomegranate) and [dynapath](https://github.com/tobias/dynapath) to `1.0.0`. [#612][612]
 - Digest `java.io.File` instead `String` path of jar at sift-action `:add-jar` method [#678][678]
+- Add warning about improper use of repl :eval option [#666][666]
 
 #### Fixed
 
@@ -56,6 +57,7 @@ and `technomancy` for the above explanation.
 [612]: https://github.com/boot-clj/boot/pull/612
 [678]: https://github.com/boot-clj/boot/pull/678
 [679]: https://github.com/boot-clj/boot/pull/679
+[666]: https://github.com/boot-clj/boot/pull/666
 
 ## 2.7.2
 

--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -473,6 +473,8 @@
    m middleware SYM [sym] "The REPL middleware vector."
    x handler SYM    sym   "The REPL handler (overrides middleware options)."]
 
+  (when (string? eval)
+    (util/warn "When passing :eval to the repl task in your build.boot, use a quoted form instead of a string\n"))
   (let [cpl-path (.getPath (core/tmp-dir!))
         srv-opts (->> [:bind :port :init-ns :middleware :handler :pod]
                       (select-keys *opts*))


### PR DESCRIPTION
Currently this works:
```
boot repl -c -e '(println "hello")'
```

but this doesn't despite being the obvious "translation" of the above.
```clojure
(deftask connect
  []
  (repl :client true
        :eval "(println \"hello\")"))
```

What's expected in this case is a quoted form; a string is just evaluated as a string essentially not doing anything:
```clojure
(deftask connect
  []
  (repl :client true
        :eval '(println "hello")))
```


The change in this PR prints a warning if a user passes a string instead of a quoted form in Clojure code / build.boot:
```
When passing :eval to the repl task in your build.boot, use a quoted form instead of a string
```

I considered just using `read-string` but a warning seems fair and might also educate the user about the differences when passing `edn` options via the CLI vs. Clojure code.

Considered adding a Changelog entry but didn't really seem interesting enough.