### PR TITLE
Bump cheshire to 5.6...

### DIFF
--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -22,7 +22,7 @@
                  [net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
                  [mvxcvi/puget                "1.0.1"]
                  [reply                       "0.3.7"]
-                 [cheshire                    "5.3.1"]
+                 [cheshire                    "5.6.0"]
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]
                  [javazoom/jlayer             "1.0.1"]


### PR DESCRIPTION
This forces the jackson.databind transitive dependency in the boot/worker project to be bumped up to 2.6, in order to fix compatability issues with s3-wagon-private version 1.3. See s3-wagon-private/s3-wagon-private#45 for more information.

The problem is the s3-wagon-private library functions are invoked within the builtin `push` task, in the context of the boot worker pod. The worker pod includes an old version cheshire, which includes a version of jackson that conflicts with s3-wagon-private.

Version 1.3 of s3-wagon-private is particularly attractive because it uses the `DefaultAWSCredentialsProviderChain`. 

To mitigate any unwanted changes I've found the earliest version (5.6) of cheshire that bumps jackson to a compatible version.
