### PR TITLE
Make `(sift :move)` create resources

### DIFF
--- a/boot/core/src/boot/task_helpers.clj
+++ b/boot/core/src/boot/task_helpers.clj
@@ -117,12 +117,14 @@
 (defmethod sift-action :move
   [_ _ args]
   (let [proc    #(reduce-kv string/replace % args)
-        reducer (fn [xs k v]
-                  (let [k (proc k)]
-                    (assoc xs k (assoc v :path k))))]
+        mkreducer (fn [dir]
+                    (fn [xs k v]
+                      (let [k (proc k)]
+                        (assoc xs k (assoc v :path k :dir dir)))))]
     (fn [fileset]
-      (->> (partial reduce-kv reducer {})
-           (update-in fileset [:tree])))))
+      (let [dir (#'core/get-add-dir fileset #{:resource})]
+        (->> (partial reduce-kv (mkreducer dir) {})
+             (update-in fileset [:tree]))))))
 
 (defmethod sift-action :add-jar
   [v? _ args]


### PR DESCRIPTION
I'll be honest - I don't know if this is a good idea, but I think
there is a genuine bug that should be addressed. The problem stems
from calling `sync-user-dirs!` at the end of the task stack - doing
so clobbers moves files that were moved via `(sift :move)` back to
their original position on the filesystem, but does not apply the
same transistion to the fileset. Files that have roles do not
suffer this inconsistency.

The result is that any post-wraps in the task stack will find that
files in the fileset they were given don't actually exist on disk.
This is also a problem when serving files from the fileset - I end
up missing any files that were moved with `sift`.