### PR TITLE
Parse complex optargs with sequential types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ and `technomancy` for the above explanation.
 - Bump [pomegranate](https://github.com/cemerick/pomegranate) and [dynapath](https://github.com/tobias/dynapath) to `1.0.0`. [#612][612]
 - Digest `java.io.File` instead `String` path of jar at sift-action `:add-jar` method [#678][678]
 - Add warning about improper use of repl :eval option [#666][666]
+- Parse complex optargs with sequential types, see [wiki section][sequential-optargs] [#682][682]
 
 #### Fixed
 
@@ -42,6 +43,7 @@ and `technomancy` for the above explanation.
 - Boot does not sign jars with classifiers [#625][625]
 - Allow clojure source jar onto the classpath [#654][654]
 - Fix `boot.tmpdir/cp` [#502][502]
+- Split an argument in three [#578][578]
 
 #### Misc
 
@@ -58,6 +60,9 @@ and `technomancy` for the above explanation.
 [678]: https://github.com/boot-clj/boot/pull/678
 [679]: https://github.com/boot-clj/boot/pull/679
 [666]: https://github.com/boot-clj/boot/pull/666
+[578]: https://github.com/boot-clj/boot/issues/578
+[682]: https://github.com/boot-clj/boot/pull/682
+[sequential-optargs]: https://github.com/boot-clj/boot/wiki/Task-Options-DSL#sequential-optargs
 
 ## 2.7.2
 

--- a/boot/core/build.boot
+++ b/boot/core/build.boot
@@ -1,17 +1,29 @@
 (set-env!
- :source-paths #{"test"}
- :dependencies '[[org.clojure/tools.reader "1.0.0-alpha2"]])
+ :source-paths #{"src" "test"}
+ :dependencies '[[org.clojure/tools.reader "1.0.0-alpha2"]
+                 [metosin/boot-alt-test "0.3.2" :scope "test"]])
+
+(ns-unmap 'boot.user 'test)
 
 (require '[boot.test :refer [runtests test-report test-exit]]
+         '[metosin.boot-alt-test :refer [alt-test]]
          'boot.task.built-in-test
          'boot.test-test)
 
 (import boot.App)
 
-(ns-unmap 'boot.user 'test)
+(deftask integration-test []
+  (comp
+   (runtests)
+   (test-report)
+   (test-exit)))
+
+(deftask unit-test []
+  (alt-test :test-matcher #"boot\.cli-test"))
 
 (deftask test []
-  (boot.util/info "Testing against version %s\n" (App/config "BOOT_VERSION"))
-  (comp (runtests)
-        (test-report)
-        (test-exit)))
+  (comp
+   (with-pass-thru [fs]
+     (boot.util/info "Testing against version %s\n" (App/config "BOOT_VERSION")))
+   (unit-test)
+   (integration-test)))

--- a/boot/core/test/boot/cli_test.clj
+++ b/boot/core/test/boot/cli_test.clj
@@ -1,0 +1,96 @@
+(ns boot.cli-test
+  (:require [boot.cli :as cli]
+            [boot.from.clojure.tools.cli :as tools-cli]
+            [clojure.test :as t]))
+
+;; this function is mocked because the original uses templates, aka runs in
+;; macro context.
+(defn- argspec->cli-argspec
+  ([short long type doc]
+   (argspec->cli-argspec short long nil type doc))
+  ([short long optarg type doc]
+   (let [doc (if-not (empty? doc) doc (format "The %s option." long))]
+     ((fnil into [])
+      (when short [:short-opt (str "-" short)])
+      [:id           (keyword long)
+       :long-opt     (str "--" long)
+       :required     (when optarg (str optarg))
+       :desc         (#'boot.cli/format-doc short optarg type doc)
+       :parse-fn     (#'boot.cli/parse-fn optarg)
+       :assoc-fn     (#'boot.cli/assoc-fn optarg type)]))))
+
+(defn- calculate-cli-args-&-opts
+  "Emulate the arg transformation code in the boot.cli/clifn macro"
+  [args argspecs]
+  (let [cli-args (->> (#'boot.cli/argspec-seq argspecs)
+                      (mapv (partial apply argspec->cli-argspec)))
+        split (#'boot.cli/split-args args)
+        [opts _] (#'boot.cli/separate-cli-opts (:cli split) cli-args)]
+    [cli-args opts]))
+
+(t/deftest cli-tests
+  (t/testing "parse-opts with simple optargs"
+    (let [argspecs '[f foo bool "Enable foo behavior."]
+          args ["-f"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "simple flag optarg should not report errors")
+      (t/is (= {:foo true} (:options parsed)) "simple flag optarg should work"))
+
+    (let [argspecs '[f foo LEVEL int "The initial foo level."]
+          args ["-f" "100"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "simple counter optarg should not report errors")
+      (t/is (= {:foo 100} (:options parsed)) "simple counter optarg should work"))
+
+    (let [argspecs '[f foo LEVELS #{int} "The set of initial foo levels."]
+          args ["-f" "100" "-f" "200" "-f" "300"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "multi-option optarg should not report errors")
+      (t/is (= {:foo #{100, 200, 300}} (:options parsed)) "multi-option optarg should work")))
+
+
+  (t/testing "parse-opts with complex optargs"
+    (let [argspecs '[f foo FOO=BAR {kw sym} "The foo option."]
+          args ["-f" "foo=bar"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "map split optarg should not report errors")
+      (t/is (= {:foo {:foo 'bar}} (:options parsed)) "map split optarg should work"))
+
+    (let [argspecs '[a parent SYM:VER=PATH [sym str str]]
+          args ["-a" "prj:1.3=parent"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "[fix #578] optarg with sequential types should not report errors")
+      (t/is (= {:parent ['prj "1.3" "parent"]} (:options parsed)) "[fix #578]  optarg with sequential should work"))
+
+    (let [argspecs '[a parent SYM:VER=PATH [sym str str]]
+          args ["-a" "overridden:X.X=uninteresting" "-a" "prj:1.3=parent"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "[fix #578] optarg with sequential types should not report errors with multiple arguments")
+      (t/is (= {:parent ['prj "1.3" "parent"]} (:options parsed)) "[fix #578]  optarg with sequential should only include the last of multiple arguments"))
+
+    (let [argspecs '[a parent SYM:VER=PATH=MORE [sym str str kw]]
+          args ["-a" "prj:1.3=parent=more-stuff"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "[fix #578] even more targets should not report errors")
+      (t/is (= {:parent ['prj "1.3" "parent" :more-stuff]} (:options parsed)) "[fix #578] even more targets optarg should work"))
+
+    (let [argspecs '[a parent SYM:VER=PATH #{[sym str str]}]
+          args ["-a" "prj:1.3=parent"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "set of vectors optarg should not report errors with a single argument")
+      (t/is (= {:parent #{['prj "1.3" "parent"]}} (:options parsed)) "set of vectors optarg should work with single arguments"))
+
+    (let [argspecs '[a parent SYM:VER=PATH #{[sym str str]}]
+          args ["-a" "foo:3.3=bar" "-a" "baz:1.4=quux"]
+          [cli-args opts] (calculate-cli-args-&-opts args argspecs)
+          parsed (tools-cli/parse-opts opts cli-args)]
+      (t/is (empty? (:errors parsed)) "set of vectors optarg should not report errors with multiple arguments")
+      (t/is (= {:parent #{['baz "1.4" "quux"] ['foo "3.3" "bar"]}} (:options parsed)) "set of vectors optarg should work with multiple arguments"))))

--- a/boot/core/test/boot/core_test.clj
+++ b/boot/core/test/boot/core_test.clj
@@ -1,7 +1,0 @@
-(ns boot.core-test
-  (:require [clojure.test :refer :all]
-            [boot.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))


### PR DESCRIPTION
This patch enables to parse options using complex optargs like `SYM:VER=PATH`
with types that are not nested but straight up sequential, like `[sym str str]`.