### PR TITLE
Add JDK 9 and cache dependencies in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
 
 install: make deps
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 install: make deps
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ jdk:
 
 install: make deps
 script: make test
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.boot/cache
+  - $HOME/bin


### PR DESCRIPTION
* Add JDK 9 to Travis for testing
* Cache dependencies in Travis which will reduce the load on Maven and Clojars since the build downloads around 300 artifacts

Successful build : https://travis-ci.org/tirkarthi/boot/builds/383569211