### PR TITLE
Test against JDK 9 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10  
 
 install: make deps
 script: make test
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis added support for JDK 9, 10 and 11 along with EA versions. I have added JDK 9 and 10 for testing. I have removed JDK 11 since there are build failures. I have also added cache for `~/.m2` which reduces load on Maven and Clojars.

I have raised a separate issue for JDK 11 at #698 