### PR TITLE
Replace printHexBinary and add JDK 11 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
+  - oraclejdk11
 
 install: make deps
 script: make test

--- a/boot/base/src/main/java/boot/App.java
+++ b/boot/base/src/main/java/boot/App.java
@@ -7,6 +7,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.FileChannel;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.Formatter;
 import java.util.Map;
 import java.util.Date;
 import java.util.UUID;
@@ -121,7 +122,15 @@ public class App {
     public static String
     md5hash(String data) throws Exception {
         java.security.MessageDigest algo = java.security.MessageDigest.getInstance("MD5");
-        return javax.xml.bind.DatatypeConverter.printHexBinary(algo.digest(data.getBytes())); }
+	return renderAsHex(algo.digest(data.getBytes())); }
+
+    private static String
+    renderAsHex(byte[] content) {
+        Formatter formatter = new Formatter();
+        for (byte b : content) {
+            formatter.format("%02X", b);
+        }
+        return formatter.toString(); }
 
     public static File
     projectDir() throws Exception {


### PR DESCRIPTION
* This removes dependency on DataTypeConverter which results in compile time error on JDK 11. 
* Add JDK 11 to Travis

Closes #698 

Ref implementation : https://github.com/twosigma/webtau/pull/58/files