### PR TITLE
Update nREPL to 0.4.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@
 
 [702]: https://github.com/boot-clj/boot/pull/702
 
+#### Breaking
+
+Updated nREPL to 0.4.4. The new nREPL has a new artefact coordinates
+(`nrepl/nrepl`) and a new namespace prefix (`clojure.tools.nrepl.` ->
+`nrepl.`). While the nREPL protocol is 100% compatible with that of
+the 0.2.x series you'll have to make sure that any middleware you're
+using has been updated to target 0.4.x. You can find more details
+[here](https://github.com/nrepl/nREPL/issues/1) and
+[here](https://github.com/nrepl/nREPL/blob/master/HISTORY.md).
+
 ## 2.8.1
 
 #### Improved
@@ -163,7 +173,7 @@ ensure that message ends in a newline.
 - Throw helpful exception when `deftask` argument vector isn't a vector [#487][487].
 - Now uses io.aviso/pretty 0.1.33: this affects the order of reported stack frames [#355][355].
   The old behavior [can be restored with user configuration][pretty-config].
-- Exceptions are now always reported using pretty, regardless of the setting of 
+- Exceptions are now always reported using pretty, regardless of the setting of
   BOOT_COLOR (or the -C flag), but when colorization is disabled, pretty
   exception reporting will not use an ANSI color codes in its output.
   This is often preferable when output from Boot is being logged to a
@@ -248,7 +258,7 @@ d- Create bootscript tmpfile with mode `0600` instead of `0664`.
   task in the fileset [#451][451].
 - Added `-C, --no-color` option to the `repl` task &mdash; disables ANSI color
   codes in REPL client output.
-  
+
 ##### Pods
 
 - Upgraded dynapath to 0.2.5 in order to support Java 9. [#528][528], [#539][539]

--- a/boot/pod/src/boot/repl.clj
+++ b/boot/pod/src/boot/repl.clj
@@ -8,7 +8,7 @@
     [boot.from.io.aviso.exception :refer [*fonts*]]))
 
 (def ^:dynamic *default-dependencies*
-  (atom '[[org.clojure/tools.nrepl "0.2.13" :exclusions [[org.clojure/clojure]]]]))
+  (atom '[[nrepl/nrepl "0.4.4" :exclusions [[org.clojure/clojure]]]]))
 
 (defn ^:private disable-exception-colors
   [handler]

--- a/boot/pod/src/boot/repl_server.clj
+++ b/boot/pod/src/boot/repl_server.clj
@@ -3,9 +3,9 @@
    [boot.repl                              :as repl]
    [boot.util                              :as util]
    [clojure.java.io                        :as io]
-   [clojure.tools.nrepl.server             :as server]
-   [clojure.tools.nrepl.middleware         :as middleware]
-   [clojure.tools.nrepl.middleware.session :as session]))
+   [nrepl.server                           :as server]
+   [nrepl.middleware                       :as middleware]
+   [nrepl.middleware.session               :as session]))
 
 (def ^:private default-opts
   {:bind       nil


### PR DESCRIPTION
As no one really commented on #695  I've decided to try an alternative approach to get some conversation going. Here's my preferred (quick) solution to the migration to the new nREPL. I know this is probably less than ideal, but it's a one time deal, and I'd really appreciate your support as I rather be dealing with nREPL improvements than with migration paths.

nREPL was recently moved out of clojure-contrib and its development
continued under a dedicated org (https://github.com/nrepl). The new project is (and will remain
to be) completely backwards compatible on the nREPL API level, but
the namespace had to be changed.

This fixes #695.