### PR TITLE
[aether] Enable Aether signing on deploy

### DIFF
--- a/boot/aether/src/boot/aether.clj
+++ b/boot/aether/src/boot/aether.clj
@@ -348,6 +348,7 @@
   (let [pom-str                                      (pod/pom-xml jarpath pompath)
         {:keys [project version classifier] :as pom} (pom-xml-parse-string pom-str)
         pomfile                                      (pom-xml-tmp pom-str)]
+    (System/setProperty "aether.checksums.forSignature" "true")
     (aether/deploy
      :coordinates  [project version :classifier classifier]
      :pom-file     (when-not classifier (io/file pomfile))


### PR DESCRIPTION
This is a straightforward fix for #705. I copied it from Leiningen, from here https://github.com/technomancy/leiningen/blob/c3de05b51f9ecdecc952625c18da3c7633836810/src/leiningen/deploy.clj#L234. If you want to enable it conditionally, or fix the push issue in some other way, feel free to iterate on the PR.