### PR TITLE
Bump reply version to 0.4.0

### DIFF
--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -2,7 +2,7 @@
  :source-paths #{"src" "test"}
  :dependencies '[[net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
                  [mvxcvi/puget                "1.0.1"]
-                 [reply                       "0.3.7"]
+                 [reply                       "0.4.0"]
                  [cheshire                    "5.3.1"]
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]

--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -23,7 +23,7 @@
                  ;; see https://github.com/boot-clj/boot/issues/82
                  [net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
                  [mvxcvi/puget                "1.0.1"]
-                 [reply                       "0.3.7"]
+                 [reply                       "0.4.0"]
                  [cheshire                    "5.6.0"]
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]


### PR DESCRIPTION
Bump reply version to 0.4.0 that uses latest clojure-complete compatible with JDK 9 and above.