### PR TITLE
Write manifest file first in update-jar!

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Fix jar creation to always write the MANIFEST.MF file as the first
+  entry (for ecosystem compatibility) [#716][716]
+
 ## 2.8.3
 
 #### Improved
@@ -30,6 +35,7 @@ using has been updated to target 0.4.x. You can find more details
 [706]: https://github.com/boot-clj/boot/pull/706
 [711]: https://github.com/boot-clj/boot/pull/711
 [713]: https://github.com/boot-clj/boot/pull/713
+[716]: https://github.com/boot-clj/boot/pull/716
 
 ## 2.8.1
 

--- a/boot/pod/src/boot/jar.clj
+++ b/boot/pod/src/boot/jar.clj
@@ -77,6 +77,6 @@
 (defn update-jar!
   [jarfile old-fs new-fs attr main]
   (with-open [^java.nio.file.FileSystem fs (fs/mkjarfs jarfile :create true)]
-    (fs/patch! (fs/->path fs) old-fs new-fs)
     (let [^java.util.jar.Manifest manifest (create-manifest main attr)]
-      (fs/write! (fs/->path fs) #(.write manifest %) ["META-INF" "MANIFEST.MF"]))))
+      (fs/write! (fs/->path fs) #(.write manifest %) ["META-INF" "MANIFEST.MF"]))
+    (fs/patch! (fs/->path fs) old-fs new-fs)))


### PR DESCRIPTION
It appears to be a de facto standard for the meta-inf directory and the manifest.mf file to be the first and second entries in the jar file.

There is no mention of ordering in the [jar specification](https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html), but it appears that most tools create Jar files with the manifest file as the first entry by using [this `JarOutputStream` constructor](https://docs.oracle.com/javase/7/docs/api/java/util/jar/JarOutputStream.html#JarOutputStream(java.io.OutputStream,%20java.util.jar.Manifest)).  In addition [the complementary jar reading code in `JarInputStream`](https://hg.openjdk.java.net/jdk10/master/file/be620a591379/src/java.base/share/classes/java/util/jar/JarInputStream.java#l79) explicitly states that it assumes the first few entries contain the manifest file.

At least [one other tool is known](https://github.com/puniverse/capsule/blob/master/capsule/src/main/java/Capsule.java#L3703) to rely on this detail of jar file ordering.

While it may not be necessary according to the spec, it seems reasonable to follow this fairly standard ecosystem behavior.

This fixes #710.