### PR TITLE
Update nREPL and REPL-y

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.8.3
+
+#### Improved
+
+- Updated REPL-y to 0.4.3.
+
 ## 2.8.2
 
 #### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 #### Improved
 
 - Updated REPL-y to 0.4.3.
+- Updated nREPL to 0.5.3.
 
 ## 2.8.2
 

--- a/boot/pod/src/boot/repl.clj
+++ b/boot/pod/src/boot/repl.clj
@@ -8,7 +8,7 @@
     [boot.from.io.aviso.exception :refer [*fonts*]]))
 
 (def ^:dynamic *default-dependencies*
-  (atom '[[nrepl/nrepl "0.5.3" :exclusions [[org.clojure/clojure]]]]))
+  (atom '[[nrepl/nrepl "0.5.3"]]))
 
 (defn ^:private disable-exception-colors
   [handler]

--- a/boot/pod/src/boot/repl.clj
+++ b/boot/pod/src/boot/repl.clj
@@ -8,7 +8,7 @@
     [boot.from.io.aviso.exception :refer [*fonts*]]))
 
 (def ^:dynamic *default-dependencies*
-  (atom '[[nrepl/nrepl "0.4.4" :exclusions [[org.clojure/clojure]]]]))
+  (atom '[[nrepl/nrepl "0.5.3" :exclusions [[org.clojure/clojure]]]]))
 
 (defn ^:private disable-exception-colors
   [handler]

--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -2,7 +2,7 @@
  :source-paths #{"src" "test"}
  :dependencies '[[net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
                  [mvxcvi/puget                "1.0.1"]
-                 [reply                       "0.4.1"]
+                 [reply                       "0.4.3"]
                  [cheshire                    "5.3.1"]
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]

--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -23,7 +23,7 @@
                  ;; see https://github.com/boot-clj/boot/issues/82
                  [net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
                  [mvxcvi/puget                "1.0.1"]
-                 [reply                       "0.4.1"]
+                 [reply                       "0.4.3"]
                  [cheshire                    "5.6.0"]
                  [clj-jgit                    "0.8.0"]
                  [clj-yaml                    "0.4.0"]


### PR DESCRIPTION
A straightforward change.

One thing to note - nREPL introduced a config file, that ideally boot should support at some point. See https://nrepl.org/nrepl/usage/server.html#_server_options

It's not a big deal and should be trivial to do. Perhaps someone like @alexander-yakushev would like to land a hand with this, as I'm not really a boot user. 