### PR TITLE
Upgrade dependencies to fix test failures on JDK 11.

### DIFF
--- a/boot/core/build.boot
+++ b/boot/core/build.boot
@@ -1,12 +1,12 @@
 (set-env!
  :source-paths #{"src" "test"}
- :dependencies '[[org.clojure/tools.reader "1.0.0-alpha2"]
-                 [metosin/boot-alt-test "0.3.2" :scope "test"]])
+ :dependencies '[[org.clojure/tools.reader "1.3.2" :exclusions [org.clojure/clojure]]
+                 [metosin/bat-test "0.4.2" :scope "test"]])
 
 (ns-unmap 'boot.user 'test)
 
 (require '[boot.test :refer [runtests test-report test-exit]]
-         '[metosin.boot-alt-test :refer [alt-test]]
+         '[metosin.bat-test :refer [bat-test]]
          'boot.task.built-in-test
          'boot.test-test)
 
@@ -19,7 +19,7 @@
    (test-exit)))
 
 (deftask unit-test []
-  (alt-test :test-matcher #"boot\.cli-test"))
+  (bat-test :test-matcher #"boot\.cli-test"))
 
 (deftask test []
   (comp

--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths #{"src" "test"}
  :dependencies '[[net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
-                 [mvxcvi/puget                "1.1.0"]
+                 [mvxcvi/puget                "1.1.1"]
                  [reply                       "0.4.3"]
                  [cheshire                    "5.8.1"]
                  [clj-jgit                    "0.8.10"]

--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -1,23 +1,23 @@
 (set-env!
  :source-paths #{"src" "test"}
  :dependencies '[[net.cgrand/parsley          "0.9.3" :exclusions [org.clojure/clojure]]
-                 [mvxcvi/puget                "1.0.1"]
-                 [reply                       "0.4.1"]
-                 [cheshire                    "5.3.1"]
-                 [clj-jgit                    "0.8.0"]
+                 [mvxcvi/puget                "1.1.0"]
+                 [reply                       "0.4.3"]
+                 [cheshire                    "5.8.1"]
+                 [clj-jgit                    "0.8.10"]
                  [clj-yaml                    "0.4.0"]
                  [javazoom/jlayer             "1.0.1"]
-                 [net.java.dev.jna/jna        "4.1.0"]
+                 [net.java.dev.jna/jna        "5.2.0"]
                  [alandipert/desiderata       "1.0.2"]
                  [org.clojure/data.xml        "0.0.8"]
-                 [org.clojure/data.zip        "0.1.1"]
+                 [org.clojure/data.zip        "0.1.2"]
                  [org.clojure/tools.namespace "0.2.11"]
 
-                 [metosin/boot-alt-test "0.3.2" :scope "test"]])
+                 [metosin/bat-test "0.4.2" :scope "test"]])
 
 (ns-unmap 'boot.user 'test)
 
-(require '[metosin.boot-alt-test :refer [alt-test]])
+(require '[metosin.bat-test :refer [bat-test]])
 
 (import boot.App)
 
@@ -25,4 +25,4 @@
   (comp
    (with-pass-thru [fs]
      (boot.util/info "Testing against version %s\n" (App/config "BOOT_VERSION")))
-   (alt-test)))
+   (bat-test)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The toArray method is now overloaded and requires type hints, and through
transitive depencies the boot-alt-test dependency dragged in an old version of
core.rrb-vector breakin the build on jdk11+.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
