### PR TITLE
Add prepl-server task

### DIFF
--- a/boot/core/src/boot/task/built_in.clj
+++ b/boot/core/src/boot/task/built_in.clj
@@ -531,6 +531,18 @@
     (core/with-pass-thru [fs]
       @repl-soc)))
 
+(core/deftask prepl-server
+  "Start a prepl server.
+
+   This task is a thin wrapper around the `socket-server` task. See the
+   docstring for `socket-server` for details."
+  [b bind ADDR str "The address server listens on."
+   p port PORT int "The port to listen to."]
+  (socket-server
+    :bind   bind
+    :accept 'clojure.core.server/io-prepl
+    :port   port))
+
 (core/deftask pom
   "Create project pom.xml file.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This adds a `prepl-server` built-in task, which is a thin wrapper around the existing `socket-server` task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

prepl-based tooling is starting to become a thing, and it's useful to be able to start a prepl server in the context of a Boot project with minimal effort.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have this task in my profile.boot and it works nicely for my personal workflow using [Conjure](https://github.com/Olical/conjure) (a prepl-based Clojure development plugin for Neovim).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  - I made an attempt... I ran `./mkdocs` and it updated a lot of things in the docs, but weirdly, it didn't add `prepl-server` to the built in tasks docs, so I didn't check the doc updates in.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
  - Unclear to me whether it's needed in this case.
- [ ] All new and existing tests passed.
