### PR TITLE
Configure Github sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: boot-clj


### PR DESCRIPTION
Since there is already a part about funding via OpenCollective I figured enabling the Github sponsor button would be a good addition. This change adds a file that configures the Github sponsor button according to the documentation here https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository

It still needs to be enabled for the project at https://github.com/boot-clj/boot/settings

