### PR TITLE
Fix watch task hanging with no directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+#### Fixed
+
+- Fix `watch` task hanging when run with no directories to watch
+
 ## 2.8.2
 
 #### Fixed

--- a/boot/tasks/src/boot/task/built_in.clj
+++ b/boot/tasks/src/boot/task/built_in.clj
@@ -367,6 +367,7 @@
             srcdirs      (->> (map (comp :dir val) (core/get-checkouts))
                               (into (core/user-dirs fileset))
                               (map (memfn getPath)))
+            _            (when-not (seq srcdirs) (throw (Exception. "No directories to watch.")))
             watcher      (apply file/watcher! :time srcdirs)
             incl-excl    (if-not (or (seq include) (seq exclude))
                            identity


### PR DESCRIPTION
## Description
A check was added to the `watch` task's startup phase for whether the list of srcdirs is non-empty. If it is found to be empty, the task now exits with an error message.

## Motivation and Context
Fixes #723.

## How Has This Been Tested?
I was unable to test this at all because I have not yet been able to build and run my modified version of boot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
