### PR TITLE
Fix Makefile for boot/base having switched from maven to lein

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ aetheruber   = aether.uber.jar
 workerjar    = boot/worker/target/worker-$(version).jar
 corejar      = boot/core/target/core-$(version).jar
 basejar      = boot/base/target/base-$(version).jar
-baseuber     = boot/base/target/base-$(version)-jar-with-dependencies.jar
+baseuber     = boot/base/target/base-$(version)-standalone.jar
 alljars      = $(podjar) $(aetherjar) $(workerjar) $(corejar) $(baseuber) $(bootjar)
 java_version = $(shell java -version 2>&1 | awk -F '"' '/version/ {print $$2}' |awk -F. '{print $$1 "." $$2}')
 
@@ -23,7 +23,7 @@ help:
 	@echo "Usage: make {help|deps|install|deploy|test|clean}" 1>&2 && false
 
 clean:
-	(cd boot/base && mvn -q clean && rm -f src/main/resources/$(aetheruber))
+	(cd boot/base && lein clean && rm -f src/main/resources/$(aetheruber))
 	(cd boot/core && lein clean)
 	(cd boot/aether && lein clean)
 	(cd boot/pod && lein clean)
@@ -44,11 +44,8 @@ bin/boot: mkdirs
 
 deps: bin/lein bin/boot
 
-boot/base/pom.xml: $(verfile) boot/base/pom.in.xml
-	(cd boot/base && cat pom.in.xml |sed 's/__VERSION__/$(version)/' > pom.xml)
-
-$(basejar): boot/base/pom.xml $(shell find boot/base/src/main/java)
-	(cd boot/base && mvn -q install)
+$(basejar): $(verfile) boot/base/project.clj $(shell find boot/base/src/main/java)
+	(cd boot/base && lein install)
 
 $(podjar): $(verfile) boot/pod/project.clj $(shell find boot/pod/src)
 	(cd boot/pod && lein install)
@@ -64,8 +61,8 @@ $(workerjar): $(verfile) boot/worker/project.clj $(shell find boot/worker/src)
 $(corejar): $(verfile) boot/core/project.clj $(shell find boot/core/src)
 	(cd boot/core && lein install)
 
-$(baseuber): boot/base/pom.xml $(shell find boot/base/src/main)
-	(cd boot/base && mvn -q assembly:assembly -DdescriptorId=jar-with-dependencies)
+$(baseuber): boot/base/project.clj $(shell find boot/base/src/main)
+	(cd boot/base && lein uberjar)
 
 $(bootjar): $(verfile) boot/boot/project.clj
 	(cd boot/boot && lein install)


### PR DESCRIPTION
Fixes the problems with the Makefile targets `clean` and `install`.

## Description

Currently the makefile has not been updated to reflect the fact that boot/base has been migrated to be built using lein rather than maven.  As a result it errors when invoked with either of these tasks. This PR fixes that by replacing the `mvn` invocations with equivalent `lein`invocations.

## How Has This Been Tested?

I ran `make clean` and `make install` and saw that they both completed successfully.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
