### PR TITLE
Fix for macOS Big Sur

### DIFF
--- a/boot/worker/build.boot
+++ b/boot/worker/build.boot
@@ -7,7 +7,7 @@
                  [clj-jgit                    "0.8.10"]
                  [clj-yaml                    "0.4.0"]
                  [javazoom/jlayer             "1.0.1"]
-                 [net.java.dev.jna/jna        "5.2.0"]
+                 [net.java.dev.jna/jna        "5.7.0"]
                  [alandipert/desiderata       "1.0.2"]
                  [org.clojure/data.xml        "0.0.8"]
                  [org.clojure/data.zip        "0.1.2"]

--- a/boot/worker/project.clj
+++ b/boot/worker/project.clj
@@ -28,7 +28,7 @@
                  [clj-jgit                    "0.8.10"]
                  [clj-yaml                    "0.4.0"]
                  [javazoom/jlayer             "1.0.1"]
-                 [net.java.dev.jna/jna        "5.2.0"]
+                 [net.java.dev.jna/jna        "5.7.0"]
                  [alandipert/desiderata       "1.0.2"]
                  [org.clojure/data.xml        "0.0.8"]
                  [org.clojure/data.zip        "0.1.3"]

--- a/boot/worker/third_party/barbarywatchservice/src/com/barbarysoftware/watchservice/WatchService.java
+++ b/boot/worker/third_party/barbarywatchservice/src/com/barbarysoftware/watchservice/WatchService.java
@@ -63,9 +63,10 @@ public abstract class WatchService implements Closeable {
     public abstract WatchKey take() throws InterruptedException;
 
     public static WatchService newWatchService() {
-        final String osVersion = System.getProperty("os.version");
-        final int minorVersion = Integer.parseInt(osVersion.split("\\.")[1]);
-        if (minorVersion < 5) {
+        final String[] osVersion = System.getProperty("os.version").split("\\.");
+        final int majorVersion = Integer.parseInt(osVersion[0]);
+        final int minorVersion = Integer.parseInt(osVersion[1]);
+        if ((majorVersion < 11) & (minorVersion < 5)) {
             throw new UnsupportedOperationException("barbarywatchservice not "
                     + "supported on Mac OS X prior to Leopard (10.5)");
             


### PR DESCRIPTION
This PR contains a fix for https://github.com/boot-clj/boot/issues/765.

## Description
Two changes have been made:
1. The dependency on `jna` has been updated to a more recent version
2. The check for macOS version in `barbarywatchservice` has been fixed so that it doesn't fail on macOS 11.*

## Motivation and Context
Before this fix, it was not possible to run `boot` on macOS Big Sur.

## How Has This Been Tested?
The changes have been tested by running `boot repl` and `boot dev` inside a Boot project on an M1 MacBook Pro.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)